### PR TITLE
Fix ThreadPool: std::result_of -> std::invoke_result_t

### DIFF
--- a/ThreadPool.h
+++ b/ThreadPool.h
@@ -9,6 +9,7 @@
 #include <functional>
 #include <future>
 #include <atomic>
+#include <type_traits>
 
 /**
  * @brief Simple thread pool for parallel task execution
@@ -62,8 +63,8 @@ public:
      */
     template<class F, class... Args>
     auto enqueue(F&& f, Args&&... args)
-        -> std::future<typename std::result_of<F(Args...)>::type> {
-        using return_type = typename std::result_of<F(Args...)>::type;
+        -> std::future<std::invoke_result_t<F, Args...>> {
+        using return_type = std::invoke_result_t<F, Args...>;
 
         auto task = std::make_shared<std::packaged_task<return_type()>>(
             std::bind(std::forward<F>(f), std::forward<Args>(args)...)


### PR DESCRIPTION
ThreadPool.h used std::result_of, deprecated in C++17 and removed in C++20, while the project targets C++23 (CMakeLists:16). Replaced with std::invoke_result_t. Build + parallel smoke test pass. Resolves kanban card-51d36be7.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated thread pool implementation to use modern C++ type deduction mechanisms, improving code standards compliance and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sirus20x6/stargen/pull/19?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->