### PR TITLE
test: regenerate golden snapshots after enviro/orbital fixes

### DIFF
--- a/tests/golden/stargen_seed_12345.txt
+++ b/tests/golden/stargen_seed_12345.txt
@@ -19,10 +19,10 @@ Planets present at:
 11	3.0651501624522978849 AU	0.5838073532638178418 EM	o
 12	4.4095270134381198187 AU	1.8592443363213155542 EM	o
 13	6.726467233692802118 AU	656.6125651986302291 EM	o
-14	13.649826586948702691 AU	0.74669522179036088813 EM	*
+14	13.649826586948702691 AU	0.74669522179036088813 EM	o
 15	18.99636213411846734 AU	5.680529274432274575 EM	o
 16	26.744272453248485406 AU	2.4075481771534598201 EM	o
-17	44.657360133327362775 AU	0.91125685055301357967 EM	*
+17	44.657360133327362775 AU	0.91125685055301357967 EM	o
 
 
 
@@ -197,7 +197,7 @@ Planet 8
    Surface temperature:		-89.110027179315197995 degrees Celcius
    Boiling point of water:	53.355861830369860854 degrees Celcius
    Hydrosphere percentage:	0%
-   Cloud cover percentage:	0.576452782901377081%
+   Cloud cover percentage:	0.576452782901376663%
    Ice cover percentage:	96.231749279429779506%
    Equatorial radius:		3972.2114418087746652 Km
    Density:			7.9396542666011936224 grams/cc
@@ -205,7 +205,7 @@ Planet 8
    Molecular weight retained:	5.9278064136401201036 and above
    Surface acceleration:	1045.5877460313689162 cm/sec2
    Axial tilt:			18.012065841058547022 degrees
-   Planetary albedo:		0.67982225118062005283
+   Planetary albedo:		0.6798222511806200524
 
 
 Planet 9
@@ -284,7 +284,7 @@ Planet 12	*gas giant*
 
 Planet 13	*gas giant*
    Distance from primary star:	6.726467233692802118 AU
-   Eccentricity of orbit:	0.0135835026550625778685
+   Eccentricity of orbit:	0.013585796883454768352
    Length of year:		6365.7542064773044928 days
    Length of day:		8.493588046675119057 hours
    Mass:			656.6125651986302291 Earth masses
@@ -305,23 +305,23 @@ Planet 14
    Mass:			0.74669522179036088813 Earth masses
    Surface gravity:		0.6753907973406547 Earth gees
    Surface pressure:		0.22241231042874857309 Earth atmospheres
-   Surface temperature:		-nan degrees Celcius
+   Surface temperature:		-209.00135397564610665 degrees Celcius
    Boiling point of water:	62.871821580101880045 degrees Celcius
-   Hydrosphere percentage:	34.499107965851873746%
-   Cloud cover percentage:	-nan%
-   Ice cover percentage:	-nan%
+   Hydrosphere percentage:	0%
+   Cloud cover percentage:	5.0061949059455136432e-06%
+   Ice cover percentage:	51.748661948777810622%
    Equatorial radius:		5925.844686218449168 Km
    Density:			5.1199975907036131945 grams/cc
    Escape Velocity:		10.024724917287180433 Km/sec
    Molecular weight retained:	0.06104982162839416776 and above
    Surface acceleration:	662.33211627407311684 cm/sec2
    Axial tilt:			5.785304912532390098 degrees
-   Planetary albedo:		-nan
+   Planetary albedo:		0.4346176454741630934
 
 
 Planet 15	*gas giant*
    Distance from primary star:	18.99636213411846734 AU
-   Eccentricity of orbit:	0.0878506286412571169
+   Eccentricity of orbit:	0.1277516186068076709
    Length of year:		30241.22031808308316 days
    Length of day:		24.913795236991554068 hours
    Mass:			5.680529274432274575 Earth masses
@@ -351,16 +351,16 @@ Planet 16	*gas giant*
 
 Planet 17
    Distance from primary star:	44.657360133327362775 AU
-   Eccentricity of orbit:	0.14806893851404717699
+   Eccentricity of orbit:	0.15662262191842463155
    Length of year:		109002.46874060795037 days
    Length of day:		24.553299916560122439 hours
    Mass:			0.91125685055301357967 Earth masses
    Surface gravity:		0.120682106966068422716 Earth gees
    Surface pressure:		0.047498150666866485557 Earth atmospheres
-   Surface temperature:		-nan degrees Celcius
+   Surface temperature:		-242.88091526656917907 degrees Celcius
    Boiling point of water:	31.572134334052805116 degrees Celcius
-   Hydrosphere percentage:	9.3623777863827307745%
-   Cloud cover percentage:	-nan%
+   Hydrosphere percentage:	0%
+   Cloud cover percentage:	1.540709811597812056e-07%
    Ice cover percentage:	100%
    Equatorial radius:		8870.482186653432684 Km
    Density:			1.8628431973639149469 grams/cc
@@ -368,4 +368,4 @@ Planet 17
    Molecular weight retained:	0.02798414836758644397 and above
    Surface acceleration:	118.34871842787948537 cm/sec2
    Axial tilt:			30.546286130806766579 degrees
-   Planetary albedo:		-nan
+   Planetary albedo:		0.69999999972267218953

--- a/tests/golden/stargen_seed_42.txt
+++ b/tests/golden/stargen_seed_42.txt
@@ -13,9 +13,9 @@ Planets present at:
 5	1.4462026994367287258 AU	3.1032148593715900868 EM	*
 6	1.9426215771489064492 AU	0.2750379764203964313 EM	o
 7	3.103655350167082982 AU	161.39123142558286671 EM	o
-8	4.803139846391668188 AU	0.09413961140091561543 EM	*
+8	4.803139846391668188 AU	0.09413961140091561543 EM	.
 9	7.4004806764832269457 AU	756.67973461501832 EM	o
-10	12.278965818860191272 AU	0.59759082458409457984 EM	*
+10	12.278965818860191272 AU	0.59759082458409457984 EM	o
 11	22.580697662660143051 AU	24.565845847945842285 EM	o
 12	40.033753666110470308 AU	2.123620957922685893 EM	o
 
@@ -47,7 +47,7 @@ Planet is tidally locked with one face to star.
 Planet 2
 Planet is tidally locked with one face to star.
    Distance from primary star:	0.42887140693515651837 AU
-   Eccentricity of orbit:	0.010528802695710321249
+   Eccentricity of orbit:	0.010529957779484963934
    Length of year:		102.58596667359151544 days
    Length of day:		2462.0632001661963706 hours
    Mass:			0.065021642960036551685 Earth masses
@@ -92,24 +92,24 @@ Planet is tidally locked with one face to star.
 
 Planet 4
    Distance from primary star:	0.9615657911871555064 AU
-   Eccentricity of orbit:	0.019033827413453684174
+   Eccentricity of orbit:	0.02782370830972668782
    Length of year:		344.40179538610635435 days
    Length of day:		21.012015206304679768 hours
    Mass:			0.70275157781690689954 Earth masses
    Surface gravity:		0.75162713921039661327 Earth gees
    Surface pressure:		0.43382358779558055268 Earth atmospheres
-   Surface temperature:		4.6687423096105901688 degrees Celcius
+   Surface temperature:		4.66874230961060821 degrees Celcius
    Boiling point of water:	78.50301780367158244 degrees Celcius
    Hydrosphere percentage:	52.750609296098830602%
-   Cloud cover percentage:	18.782647234953844728%
-   Ice cover percentage:	7.570549012043347025%
+   Cloud cover percentage:	18.782647234953841033%
+   Ice cover percentage:	7.5705490120433486037%
    Equatorial radius:		5577.169033982171174 Km
    Density:			5.7801297246535810557 grams/cc
    Escape Velocity:		10.024666222354255151 Km/sec
    Molecular weight retained:	10.572275204150362998 and above
    Surface acceleration:	737.0944284737635674 cm/sec2
    Axial tilt:			25.067956347512556192 degrees
-   Planetary albedo:		0.179942514023187845
+   Planetary albedo:		0.17994251402318783221
 
 
 Planet 5
@@ -120,18 +120,18 @@ Planet 5
    Mass:			3.1032148593715900868 Earth masses
    Surface gravity:		2.5779367412443085922 Earth gees
    Surface pressure:		10.984878494906831799 Earth atmospheres
-   Surface temperature:		3.7142659643520964385 degrees Celcius
+   Surface temperature:		3.71426596435206971 degrees Celcius
    Boiling point of water:	180.6019024174443075 degrees Celcius
    Hydrosphere percentage:	70.370370370370370364%
-   Cloud cover percentage:	27.065735135070530202%
-   Ice cover percentage:	9.353199202735075718%
+   Cloud cover percentage:	27.065735135070486356%
+   Ice cover percentage:	9.353199202735092697%
    Equatorial radius:		7505.3186768770296147 Km
    Density:			10.473253436246954251 grams/cc
    Escape Velocity:		18.159223125902956817 Km/sec
    Molecular weight retained:	1.0358830994734200595 and above
    Surface acceleration:	2528.0923343523497917 cm/sec2
    Axial tilt:			20.082099898312282704 degrees
-   Planetary albedo:		0.21126292268208436981
+   Planetary albedo:		0.21126292268208420219
 
 
 Planet 6
@@ -179,10 +179,10 @@ Planet 8
    Mass:			0.09413961140091561543 Earth masses
    Surface gravity:		0.2891003280524544533 Earth gees
    Surface pressure:		0.0030111928022058013938 Earth atmospheres
-   Surface temperature:		-nan degrees Celcius
+   Surface temperature:		-180.85392555910557633 degrees Celcius
    Boiling point of water:	-11.905582080607814532 degrees Celcius
-   Hydrosphere percentage:	17.337226678939270625%
-   Cloud cover percentage:	-nan%
+   Hydrosphere percentage:	0%
+   Cloud cover percentage:	5.1178261218939435873e-05%
    Ice cover percentage:	100%
    Equatorial radius:		3289.2928254821448335 Km
    Density:			3.7743482259542764133 grams/cc
@@ -190,7 +190,7 @@ Planet 8
    Molecular weight retained:	1.8994134163598527204 and above
    Surface acceleration:	283.51057320956023594 cm/sec2
    Axial tilt:			20.745955824338068396 degrees
-   Planetary albedo:		-nan
+   Planetary albedo:		0.69999990787912976154
 
 
 Planet 9	*gas giant*
@@ -216,10 +216,10 @@ Planet 10
    Mass:			0.59759082458409457984 Earth masses
    Surface gravity:		0.55380970379958430964 Earth gees
    Surface pressure:		0.13162690735216398192 Earth atmospheres
-   Surface temperature:		-nan degrees Celcius
+   Surface temperature:		-215.42486990617035758 degrees Celcius
    Boiling point of water:	51.540033666614363028 degrees Celcius
-   Hydrosphere percentage:	30.616005642474573189%
-   Cloud cover percentage:	-nan%
+   Hydrosphere percentage:	0%
+   Cloud cover percentage:	4.925925181452240028e-06%
    Ice cover percentage:	100%
    Equatorial radius:		5714.1026278385782438 Km
    Density:			4.5702187763452564923 grams/cc
@@ -227,12 +227,12 @@ Planet 10
    Molecular weight retained:	0.09089757761769146759 and above
    Surface acceleration:	543.10179317661932685 cm/sec2
    Axial tilt:			6.8910211093653268577 degrees
-   Planetary albedo:		-nan
+   Planetary albedo:		0.699999991133334629
 
 
 Planet 11	*gas giant*
    Distance from primary star:	22.580697662660143051 AU
-   Eccentricity of orbit:	0.1530909005697208003
+   Eccentricity of orbit:	0.15810985367522781275
    Length of year:		39191.09187488894094 days
    Length of day:		18.629764229465160573 hours
    Mass:			24.565845847945842285 Earth masses
@@ -247,7 +247,7 @@ Planet 11	*gas giant*
 
 Planet 12	*gas giant*
    Distance from primary star:	40.033753666110470308 AU
-   Eccentricity of orbit:	0.12886339897302745428
+   Eccentricity of orbit:	0.13780448878720910622
    Length of year:		92519.961178089340514 days
    Length of day:		32.541894914337425912 hours
    Mass:			2.123620957922685893 Earth masses

--- a/tests/golden/stargen_seed_7.txt
+++ b/tests/golden/stargen_seed_7.txt
@@ -96,18 +96,18 @@ Planet 4
    Mass:			1.9170235954703192081 Earth masses
    Surface gravity:		2.5287402398861933363 Earth gees
    Surface pressure:		4.6442595651811713247 Earth atmospheres
-   Surface temperature:		12.534689450091968166 degrees Celcius
+   Surface temperature:		12.534689450091963753 degrees Celcius
    Boiling point of water:	148.02615724411072051 degrees Celcius
    Hydrosphere percentage:	95.122694711172077434%
-   Cloud cover percentage:	61.28852334526285305%
-   Ice cover percentage:	3.864082512344786383%
+   Cloud cover percentage:	61.288523345262808956%
+   Ice cover percentage:	3.8640825123447951276%
    Equatorial radius:		6257.1053040973989257 Km
    Density:			11.165656024945998546 grams/cc
    Escape Velocity:		15.631581079986256081 Km/sec
    Molecular weight retained:	2.211841308860327082 and above
    Surface acceleration:	2479.8470473479936962 cm/sec2
    Axial tilt:			8.2140972621772085915 degrees
-   Planetary albedo:		0.35828469180199749703
+   Planetary albedo:		0.35828469180199731228
 
 
 Planet 5	*gas giant*
@@ -157,7 +157,7 @@ Planet 7	*gas giant*
 
 Planet 8	*gas giant*
    Distance from primary star:	16.085196639894813594 AU
-   Eccentricity of orbit:	0.055951021575374515482
+   Eccentricity of orbit:	0.056563958043302990653
    Length of year:		23563.04445445240686 days
    Length of day:		22.61635859569425033 hours
    Mass:			8.4561714727484781845 Earth masses
@@ -172,16 +172,16 @@ Planet 8	*gas giant*
 
 Planet 9
    Distance from primary star:	34.215634654070733227 AU
-   Eccentricity of orbit:	0.07706571127276359845
+   Eccentricity of orbit:	0.112916272777889598045
    Length of year:		73102.824693003564214 days
    Length of day:		26.90064370224006047 hours
    Mass:			0.15372132106926725915 Earth masses
    Surface gravity:		0.35624114246039080233 Earth gees
    Surface pressure:		2.6607096995774364205e-05 Earth atmospheres
-   Surface temperature:		-nan degrees Celcius
+   Surface temperature:		-238.56932132985353927 degrees Celcius
    Boiling point of water:	-63.24935643991722145 degrees Celcius
-   Hydrosphere percentage:	0.07163035326005992144%
-   Cloud cover percentage:	-nan%
+   Hydrosphere percentage:	0%
+   Cloud cover percentage:	1.6825884885275858787e-09%
    Ice cover percentage:	100%
    Equatorial radius:		3991.5969537055325251 Km
    Density:			3.4488256420034815195 grams/cc
@@ -189,21 +189,21 @@ Planet 9
    Molecular weight retained:	0.031790338285747578186 and above
    Surface acceleration:	349.3532199709191332 cm/sec2
    Axial tilt:			39.599548905940238797 degrees
-   Planetary albedo:		-nan
+   Planetary albedo:		0.6999999999969712963
 
 
 Planet 10
    Distance from primary star:	48.215196160164372582 AU
-   Eccentricity of orbit:	0.055872993774018407664
+   Eccentricity of orbit:	0.06741210509082971869
    Length of year:		122284.98038136711079 days
    Length of day:		24.280406117524790256 hours
    Mass:			0.22609161332517152814 Earth masses
    Surface gravity:		0.46121384611694886925 Earth gees
    Surface pressure:		6.32411833682437442e-05 Earth atmospheres
-   Surface temperature:		-nan degrees Celcius
+   Surface temperature:		-244.01910395920093677 degrees Celcius
    Boiling point of water:	-55.414799228696324462 degrees Celcius
-   Hydrosphere percentage:	0.08440215771471848399%
-   Cloud cover percentage:	-nan%
+   Hydrosphere percentage:	0%
+   Cloud cover percentage:	1.2646062006787693713e-09%
    Ice cover percentage:	100%
    Equatorial radius:		4369.332842553535995 Km
    Density:			3.8673746261910869541 grams/cc
@@ -211,4 +211,4 @@ Planet 10
    Molecular weight retained:	0.011915014501346481988 and above
    Surface acceleration:	452.2962764022776461 cm/sec2
    Axial tilt:			62.742391263181410466 degrees
-   Planetary albedo:		-nan
+   Planetary albedo:		0.69999999999772366446


### PR DESCRIPTION
## What

Regenerate the three committed golden snapshots (`tests/golden/stargen_seed_{12345,42,7}.txt`) so they match current `master`.

## Why

The fixes merged for #20 / #22 / #23 / #26 intentionally changed generator output. That left the goldens stale and the `golden_regression` ctest (local-only, excluded from CI) red — which **blocks the `pre-commit` hook on every subsequent commit** (`scripts/verify.sh` refuses a red tree).

## The diff is the expected correctness improvement

- **`-nan` → real values** for Surface temperature / Cloud cover / Ice cover / Planetary albedo on cold outer planets (enviro numerical-bug fixes).
- **Orbital eccentricities update** (Keplerian math fixes) — e.g. seed 7 Planet 9: `0.0770…` → `0.1129…`.
- A few **habitability-map symbols flip** (`*` → `o` / `.`) where planets were previously mis-flagged habitable via NaN comparisons.
- Minor **last-ULP FP shifts** from refactor reassociation.

Regenerated from the gcc build of current `master` via:

```
STARGEN_UPDATE_GOLDENS=1 cmake -DSTARGEN_BIN=./stargen \
  -DGOLDEN_DIR=tests/golden -DSEEDS="12345;42;7" \
  -DWORKING_DIR=. -P tests/golden_regression.cmake
```

## Verification

`scripts/verify.sh` → 100% tests passed, 0 tests failed out of 9; `golden_regression` now passes in compare mode (also confirmed by the `pre-commit` hook on the commit in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test expectations for stargen planetary generation across multiple seed scenarios. Corrected several planetary characteristics including orbital eccentricity, surface temperature, atmospheric properties, and albedo values. Resolved instances where calculations previously produced invalid values, replacing them with properly computed numeric results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->