### PR TITLE
build/test: make the Windows CI lane green (m.lib + RuntimeLibrary + determinism harness)

### DIFF
--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -54,7 +54,7 @@ jobs:
       shell: pwsh
       working-directory: build
       # Skip local-only tests (golden_regression) — non-portable FP goldens; see ci.yml.
-      run: ctest -C ${{ env.BUILD_TYPE }} --label-exclude local-only
+      run: ctest -C ${{ env.BUILD_TYPE }} --output-on-failure --label-exclude local-only
 
     # Package
     - name: Package the Build (Windows)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,21 @@
 cmake_minimum_required(VERSION 3.5...4.99)
 set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
+
+# Windows (clang targeting the MSVC STL): our own targets compile against the
+# dynamic C runtime (msvcrt), but the FetchContent dependencies (Tracy,
+# yaml-cpp) declare old cmake_minimum_required values, so CMP0091 reverts to OLD
+# in their scope and they select a different CRT. lld-link then aborts the final
+# link with "/failifmismatch: mismatch detected for 'RuntimeLibrary'". Forcing
+# CMP0091 NEW for every project -- ours and the dependencies' -- routes all of
+# them through CMAKE_MSVC_RUNTIME_LIBRARY, which we pin to the dynamic CRT so the
+# embedded runtime directives agree. These settings only affect MSVC-ABI builds;
+# on the gcc/clang Linux lanes they are inert.
+set(CMAKE_POLICY_DEFAULT_CMP0091 NEW)
+if(POLICY CMP0091)
+  cmake_policy(SET CMP0091 NEW)
+endif()
+set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
+
 project(stargen VERSION 3.0.0.0 DESCRIPTION "A program for generating solar systems")
 
 # Assuming GIT_VERSION is set externally (e.g., by your CI, a FindGit.cmake module, or environment variable)
@@ -77,6 +93,16 @@ endif()
 option(STARGEN_BUILD_VIEWER "Build the raylib-based real-time viewer" ON)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR})
+
+# The standard math library is a separate link target on Linux/BSD (libm) but is
+# folded into the C runtime on Windows and macOS. Linking "m" explicitly on
+# Windows makes lld-link search for a nonexistent m.lib and fail; only reference
+# it on platforms where it is a real library.
+if(WIN32)
+  set(STARGEN_MATH_LIB "")
+else()
+  set(STARGEN_MATH_LIB m)
+endif()
 
 cmake_host_system_information(RESULT logical QUERY NUMBER_OF_LOGICAL_CORES)
 cmake_host_system_information(RESULT physical QUERY NUMBER_OF_PHYSICAL_CORES)
@@ -200,7 +226,7 @@ target_include_directories(stargen_core PUBLIC
 target_link_libraries(stargen_core PUBLIC
     TracyClient                     # Links the Tracy library and sets up its include paths.
     nlohmann_json::nlohmann_json
-    m                               # Standard math library
+    ${STARGEN_MATH_LIB}             # Standard math library (libm; empty on Windows/macOS)
     yaml-cpp
 )
 
@@ -276,7 +302,7 @@ target_include_directories(orbital_demo PRIVATE ${CMAKE_SOURCE_DIR}/tracy)
 target_link_libraries(orbital_demo PRIVATE
     TracyClient
     nlohmann_json::nlohmann_json
-    m
+    ${STARGEN_MATH_LIB}
     yaml-cpp
 )
 
@@ -330,7 +356,7 @@ target_include_directories(viewer PRIVATE ${CMAKE_SOURCE_DIR}/tracy)
 target_link_libraries(viewer PRIVATE
     TracyClient
     nlohmann_json::nlohmann_json
-    m
+    ${STARGEN_MATH_LIB}
     yaml-cpp
     raylib
 )

--- a/tests/determinism_threads_test.cpp
+++ b/tests/determinism_threads_test.cpp
@@ -60,22 +60,39 @@ std::string generate_json(const fs::path& run_dir, int threads, long seed,
   std::error_code ec;
   fs::remove_all(run_dir, ec);
   fs::create_directories(run_dir / "html");
-  // Make stargen's input data resolvable relative to this cwd.
+  // Make stargen's input data resolvable relative to this cwd. On POSIX a
+  // symlink is cheapest, but on Windows creating one needs a privilege the CI
+  // runner lacks (the call would throw), so copy the small data tree instead.
+#ifdef _WIN32
+  fs::copy(fs::path(STARGEN_SOURCE_DIR) / "data", run_dir / "data",
+           fs::copy_options::recursive);
+#else
   fs::create_directory_symlink(fs::path(STARGEN_SOURCE_DIR) / "data",
                                run_dir / "data");
+#endif
   // Drop the sentinel marker so stargen will write into ./html.
   { std::ofstream(run_dir / "html" / kMarkerName) << "marker\n"; }
 
+  // Shell differences: cmd.exe needs the null device spelled NUL and a
+  // drive-aware `cd /d`; POSIX shells use /dev/null and a plain cd. Both honor
+  // `&&`, quoting, and `2>&1`.
+#ifdef _WIN32
+  const char* kCd = "cd /d ";
+  const char* kNull = "NUL";
+#else
+  const char* kCd = "cd ";
+  const char* kNull = "/dev/null";
+#endif
   std::ostringstream cmd;
   // cd into the private dir so data/ resolves and output lands in ./html.
   // Fixed seed (-s) and count (-n) with a star mass (-m) so the parallel path
   // runs; JSON output (-JS); -o sets the base filename; -T# the thread count.
-  cmd << "cd \"" << run_dir.string() << "\" && "
+  cmd << kCd << '"' << run_dir.string() << "\" && "
       << '"' << STARGEN_BIN << '"'
       << " -s" << seed << " -n12 -m1.0 -JS"
       << " -o " << out_name
       << " -T" << threads
-      << " > /dev/null 2>&1";
+      << " > " << kNull << " 2>&1";
 
   int rc = std::system(cmd.str().c_str());
   REQUIRE(rc == 0);


### PR DESCRIPTION
## What

Make the **Windows CI lane** (clang targeting the MSVC STL, `lld-link`) fully green. The lane had three independent Windows-only problems, fixed in two commits.

## 1 & 2 — link failures (`CMakeLists.txt`)

```
lld-link: error: could not open 'm.lib': no such file or directory
lld-link: error: /failifmismatch: mismatch detected for 'RuntimeLibrary'
```

- **`m.lib`** — the math library was linked unconditionally as `m` in three targets (`stargen_core`, `orbital_demo`, `viewer`). `libm` is a separate library only on Linux/BSD; on Windows (and macOS) the math functions live in the C runtime, so `lld-link` searched for a nonexistent `m.lib`. Now gated behind a `STARGEN_MATH_LIB` variable: `m` off-Windows, empty on Windows.
- **`RuntimeLibrary` mismatch** — our targets compile against the dynamic CRT (`msvcrt`), but the FetchContent deps (Tracy, yaml-cpp) declare old `cmake_minimum_required` values, so `CMP0091` reverted to OLD in their scope and they picked a different CRT, which `lld-link` rejects via the embedded `/failifmismatch` directive. Now `CMP0091` is forced `NEW` for every project and `CMAKE_MSVC_RUNTIME_LIBRARY` is pinned to the dynamic CRT.

## 3 — determinism test harness was Unix-only (`tests/determinism_threads_test.cpp`)

With the link fixed, the lane reached the test stage and failed Test #8 ("output is identical regardless of worker-thread count") in **0.45 s** — too fast to have run any generation, so the *harness*, not the generator, was breaking. Two Unix-isms:

- `fs::create_directory_symlink` to stage `data/` — needs a privilege the Windows runner lacks (throws). Now copies the small `data/` tree on Windows instead.
- `> /dev/null` with a plain `cd` — cmd.exe needs `NUL` and a drive-aware `cd /d`.

Both guarded by `#ifdef _WIN32`; the POSIX path is unchanged. Also added `--output-on-failure` to the Windows `ctest` step (parity with `ci.yml`) so any genuine byte-diff is visible.

## Verification

- **Linux** (the merge gate): `scripts/verify.sh` → 100% tests passed, 0 tests failed out of 9 (determinism test included). Re-confirmed by the gcc/clang CI lanes.
- **Windows**: not reproducible locally; validated by this PR's Windows CI lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
