### PR TITLE
build: first-party -Wall/-Wextra + gate Tracy behind ENABLE_TRACY (default off)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,16 +64,23 @@ else()
   set(STARGEN_BIN_OUTPUT_DIR "${CMAKE_SOURCE_DIR}")
 endif()
 
-# Tracy is a profiler. Its bundled rpmalloc allocator recycles memory spans
-# across threads without synchronization that ThreadSanitizer can observe, and
-# its profiler worker threads touch shared globals -- both produce a flood of
-# TSan false positives that drown out real data races. So in a sanitizer build
-# we disable Tracy entirely: the Tracy CMake option is forced OFF (TracyClient
-# becomes a stub with no profiler threads and no rpmalloc), and we do not define
-# TRACY_ENABLE for our targets (the Tracy.hpp macros like ZoneScoped then expand
-# to nothing). TracyClient is still linked so its headers remain on the include
-# path. Normal (non-sanitizer) builds keep full Tracy instrumentation.
-if(SANITIZE)
+# Tracy is a profiler, gated behind ENABLE_TRACY so production / release / CI
+# builds can ship without it: it spawns profiler worker threads, opens a listen
+# socket, and adds runtime overhead (README advises disabling it for production).
+# Default OFF -- opt in for local profiling with -DENABLE_TRACY=ON.
+#
+# Tracy is ALSO forced off under any sanitizer build regardless of ENABLE_TRACY:
+# its bundled rpmalloc allocator recycles memory spans across threads without
+# synchronization that ThreadSanitizer observes, and its worker threads touch
+# shared globals -- both flood TSan with false positives that drown out real
+# data races.
+#
+# When Tracy is off, the fetched Tracy CMake target becomes a stub (no profiler
+# threads, no rpmalloc) and we do not define TRACY_ENABLE for our code, so the
+# Tracy.hpp macros (ZoneScoped, etc.) expand to nothing. TracyClient is still
+# linked either way so its headers remain on the include path.
+option(ENABLE_TRACY "Build with Tracy profiler instrumentation" OFF)
+if(SANITIZE OR NOT ENABLE_TRACY)
   set(TRACY_ENABLE OFF CACHE BOOL "" FORCE)   # affects the fetched Tracy build
   set(STARGEN_TRACY_DEFINES "")               # no TRACY_ENABLE for our code
 else()
@@ -198,25 +205,43 @@ add_library(stargen_core STATIC
 )
 
 # ----------------------------------------------------------------------------
-# clang optimizer workaround for the large predefined star catalogues.
-# ring_universe.cpp, ic3094_2.cpp and andromeda2.cpp (and the not-currently-
-# compiled ring_universe2.cpp) are enormous static tables whose entries are
-# built from runtime calls -- mass(abs2luminosity(...)) -- tens of thousands of
-# times, producing one huge dynamic initializer. clang's optimizer (verified on
-# clang-18/21/22) spins on that effectively forever at every -O level except
-# -O0, while gcc compiles it fine in seconds. These translation units are pure
-# data, so forcing -O0 under clang costs nothing at runtime and lets the clang
-# build complete. (Source COMPILE_OPTIONS are emitted after CMAKE_CXX_FLAGS_*,
-# so this -O0 overrides the Release -O3 for just these files.)
+# Generated star-catalogue translation units. These are enormous machine-style
+# data tables, not first-party logic, so they get special compile handling:
+#
+#  * -w: keep them OUT of the -Wall/-Wextra first-party warning set added below;
+#    they would otherwise emit thousands of warnings that bury the real ones.
+#  * -O0 under clang: ring_universe.cpp, ic3094_2.cpp and andromeda2.cpp build
+#    their entries from tens of thousands of runtime calls -- mass(abs2luminosity
+#    (...)) -- producing one huge dynamic initializer that clang's optimizer
+#    (verified on clang-18/21/22) spins on effectively forever at every -O level
+#    except -O0, while gcc compiles it in seconds. These TUs are pure data, so
+#    forcing -O0 under clang costs nothing at runtime; applying it to all the
+#    catalogue files (not just the three that hang) is harmless and simpler.
+#
+# COMPILE_OPTIONS is a single per-source list emitted after CMAKE_CXX_FLAGS_*,
+# so -w / -O0 here override the target's -Wall and the Release -O3 for just
+# these files.
+set(STARGEN_CATALOG_SOURCES
+    andromeda.cpp
+    andromeda2.cpp
+    ic3094.cpp
+    ic3094_2.cpp
+    jimb.cpp
+    omega_galaxy.cpp
+    omega_galaxy2.cpp
+    Planetary_Habitability_Laboratory.cpp
+    ring_universe.cpp
+    solstation.cpp
+    star_trek.cpp
+)
+set(STARGEN_CATALOG_COMPILE_OPTIONS -w)
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    set_source_files_properties(
-        ring_universe.cpp
-        ring_universe2.cpp
-        ic3094_2.cpp
-        andromeda2.cpp
-        PROPERTIES COMPILE_OPTIONS "-O0"
-    )
+    list(APPEND STARGEN_CATALOG_COMPILE_OPTIONS -O0)
 endif()
+set_source_files_properties(
+    ${STARGEN_CATALOG_SOURCES}
+    PROPERTIES COMPILE_OPTIONS "${STARGEN_CATALOG_COMPILE_OPTIONS}"
+)
 
 target_compile_definitions(stargen_core PUBLIC ${STARGEN_TRACY_DEFINES})
 target_include_directories(stargen_core PUBLIC
@@ -229,6 +254,15 @@ target_link_libraries(stargen_core PUBLIC
     ${STARGEN_MATH_LIB}             # Standard math library (libm; empty on Windows/macOS)
     yaml-cpp
 )
+
+# First-party warning flags: -Wall/-Wextra on our own translation units. The
+# generated catalogue TUs are excluded via -w above. NOT -Werror -- warnings are
+# for visibility and must not break the build. PRIVATE so they don't leak into
+# the test target (which compiles Catch2) or other consumers. Guarded to the
+# GNU/Clang frontends (the only compilers this project builds with; the Windows
+# lane uses clang++).
+target_compile_options(stargen_core PRIVATE
+    $<$<CXX_COMPILER_ID:GNU,Clang>:-Wall;-Wextra>)
 
 # stargen executable = main.cpp + stargen_core
 add_executable(stargen
@@ -245,6 +279,10 @@ target_include_directories(stargen PRIVATE ${CMAKE_SOURCE_DIR}/tracy)
 target_link_libraries(stargen PRIVATE
     stargen_core
 )
+
+# First-party warnings for main.cpp too (see stargen_core note above).
+target_compile_options(stargen PRIVATE
+    $<$<CXX_COMPILER_ID:GNU,Clang>:-Wall;-Wextra>)
 
 # Set the binary output directory to the source directory
 set_target_properties(stargen PROPERTIES

--- a/README.md
+++ b/README.md
@@ -36,6 +36,17 @@ make -jx
 ```
 where x is number of threads +1 to compile faster
 
+### Build options
+Pass these with `-D<option>=<value>` at configure time:
+
+| Option | Default | Effect |
+| --- | --- | --- |
+| `ENABLE_TRACY` | `OFF` | Build with the Tracy profiler (worker threads + listen socket + overhead). Off by default for production/CI; turn on for local profiling: `cmake -B build -DENABLE_TRACY=ON`. Always forced off under `SANITIZE`. |
+| `SANITIZE` | *(empty)* | `address`, `thread`, or `undefined` — build with that sanitizer (use a separate build dir, e.g. `cmake -B build-asan -DSANITIZE=address`). |
+| `STARGEN_BUILD_VIEWER` | `ON` | Build the raylib real-time viewer. CI sets it `OFF` (headless, no display backend). |
+
+First-party sources build with `-Wall -Wextra` (not `-Werror`); the large generated star-catalogue translation units are compiled with `-w` to keep their machine-generated noise out of the warning stream.
+
 ## Command Line Usage
 ```
 Usage: stargen [options] [system name]


### PR DESCRIPTION
## What

Roadmap card **"Harden build: warnings, sanitizers, gate Tracy behind an option"** (`card-982995e6`). The sanitizer preset already shipped (the `SANITIZE` option, PR #27), so this PR does the two remaining parts.

## 1. First-party warning flags

- `-Wall -Wextra` on our own translation units (`stargen_core` + `main.cpp`), genex-guarded to the GNU/Clang frontends. **Not** `-Werror` — warnings are for visibility and must never break the build.
- The large **generated star-catalogue** TUs (`omega_galaxy*`, `ring_universe*`, `ic3094*`, `andromeda*`, `jimb`, `solstation`, `star_trek`, PHL) are compiled with `-w` so their machine-generated noise doesn't bury real warnings. This is merged with the existing clang `-O0` per-file workaround (`COMPILE_OPTIONS` is a single list per source, so both must be set together) and now covers all catalogue files.

## 2. Gate Tracy behind `ENABLE_TRACY`

Tracy was hardcoded on for every build, including Release CI (it spawns profiler threads, opens a listen socket, adds overhead). Now `option(ENABLE_TRACY OFF)`:
- **Default OFF** → production/CI builds ship without the profiler.
- Opt in locally with `cmake -B build -DENABLE_TRACY=ON`.
- Still force-disabled under any `SANITIZE` build (unchanged).

README gains a **Build options** table documenting `ENABLE_TRACY`, `SANITIZE`, and `STARGEN_BUILD_VIEWER`.

## Verification

- `scripts/verify.sh` (gcc) → **100% tests passed, 0 failed out of 9**, including `golden_regression` — confirming Tracy-off-by-default does **not** change generator output (goldens were baked with Tracy on).
- `compile_commands.json` checked: first-party TUs carry `-Wall` and no `TRACY_ENABLE`; catalogue TUs carry `-w`.
- clang + Windows lanes validated by this PR's CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build configuration with new ENABLE_TRACY option for Tracy instrumentation control
  * Tracy now automatically disabled when using sanitizer builds
  * Enhanced compiler warning flags for first-party code

* **Documentation**
  * Added Build options section documenting CMake configuration flags

<!-- end of auto-generated comment: release notes by coderabbit.ai -->