### PR TITLE
fix(output): restore byte-identical float formatting after C++26 migration

### DIFF
--- a/utils.h
+++ b/utils.h
@@ -3,11 +3,13 @@
 #include <stddef.h>   // for size_t
 #include <algorithm>  // for replace
 #include <cmath>      // for isnan
+#include <cstdio>     // for std::snprintf (standard-stable float formatting)
 #include <iomanip>    // for operator<<, setprecision
 #include <iostream>   // for cout, basic_ostream<>::__ostream_...
 #include <sstream>    // for std::stringstream (not guaranteed via <iostream>)
 #include <map>        // for std::map
 #include <string>     // for std::string, to_string
+#include <type_traits>  // for std::is_floating_point_v, std::is_same_v
 #include <vector>     // for std::vector
 #include "stargen.h"  // for decimals_arg
 #include "tracy/Tracy.hpp"
@@ -99,7 +101,25 @@ auto toString(T val, int decimals) -> std::string {
   } else {
     if (decimals == 0) {
       // ss << std::showpoint << std::fixed << std::setprecision(getNumDecimals(val));
-      output = std::to_string(val);
+      if constexpr (std::is_floating_point_v<T>) {
+        // C++26 (libstdc++ P2587) changed std::to_string for floating-point
+        // types from printf "%f"/"%Lf" (6 fractional digits) to a shortest
+        // round-trip representation. That silently altered every toString()
+        // value in CSV/HTML/JSON output. Replicate the historical "%f"/"%Lf"
+        // behavior directly so output stays byte-identical and standard-stable.
+        if constexpr (std::is_same_v<T, long double>) {
+          int n = std::snprintf(nullptr, 0, "%Lf", val);
+          output.resize(n);
+          std::snprintf(output.data(), n + 1, "%Lf", val);
+        } else {
+          double d = static_cast<double>(val);
+          int n = std::snprintf(nullptr, 0, "%f", d);
+          output.resize(n);
+          std::snprintf(output.data(), n + 1, "%f", d);
+        }
+      } else {
+        output = std::to_string(val);
+      }
     } else {
       ss << std::showpoint << std::fixed << std::setprecision(decimals);
       ss << val;


### PR DESCRIPTION
## Problem

The C++26 migration (#35) bumped the toolchain from C++23 to C++26. C++26 (libstdc++ P2587, gated on `__glibcxx_to_string >= 202306`) **changed `std::to_string` for floating-point types** from printf `"%f"`/`"%Lf"` (6 fractional digits) to a shortest round-trip representation.

`utils.h` `toString()`'s default (`decimals == 0`) branch used `std::to_string`, so the bump **silently altered every toString-formatted value** in:
- **CSV** — the star header line
- **HTML** — per-planet detail tables
- **JSON** — atmosphere strings

e.g. `"N 97.433175"` → `"N 97.43317543130158"`.

This slipped through #35's "byte-identical" verification because that check's *old* reference binary was already C++26 (the toolchain commit), so the regression cancelled out in the diff. `golden_regression` also missed it (it uses `-t` text, which formats via `std::format`, unaffected).

## Fix

Replicate the historical `"%f"`/`"%Lf"` formatting directly via `snprintf` for floating-point `T`. Integers keep `std::to_string` (unchanged across standards). Output is now byte-identical to the original C++23 stargen **and** independent of the active C++ standard. One file, +21/-1.

## Verification

Differential against the true pre-#35 C++23 master (`c714c7a`), both built `-O3`/Release under the same `stargen` basename:
- **JSON + CSV byte-identical** across 6 seeds (12345, 777, 31337, 1, 42, 99999) — `-n12 -m1.0 -g -M`
- **72/72 per-system HTML files byte-identical** across those seeds
- `scripts/verify.sh`: **9/9 ctest pass**

(An initial diff run showed 1-ULP differences in full-precision JSON numbers — traced to comparing `-O0` vs `-O3` builds, not a real regression; resolved by matching optimization levels.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved floating-point number formatting and string conversion accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->