### PR TITLE
fix(io): elements YAML loader throws instead of exit(); validate + configurable path

### DIFF
--- a/elements.cpp
+++ b/elements.cpp
@@ -5,14 +5,24 @@
 #include "structs.h"  // for ChemTable, Chemical
 #include <yaml-cpp/yaml.h> // for YAML parsing
 #include <fstream>
+#include <stdexcept>  // for std::runtime_error
 
 ChemTable gases;
 
 void loadElementsFromYAML(const std::string& filename) {
+    int loaded = 0;
     try {
         YAML::Node config = YAML::LoadFile(filename);
-        
+
         for (const auto& node : config) {
+            // A non-positive atomic weight would feed downstream divisions and
+            // produce NaN/inf. (density CAN legitimately be 0.0 in the shipped
+            // table for some synthetic elements, so it is not rejected here.)
+            if (node["atomic_weight"].as<double>() <= 0.0) {
+                throw std::runtime_error(
+                    "StarGen: element '" + node["symbol"].as<std::string>() +
+                    "' in '" + filename + "' has a non-positive atomic weight");
+            }
             Chemical chem(
                 node["atomic_number"].as<int>(),
                 node["symbol"].as<std::string>(),
@@ -32,14 +42,22 @@ void loadElementsFromYAML(const std::string& filename) {
                 node["min_inspired_pp"].as<double>()
             );
             gases.addChemicle(chem);
+            ++loaded;
         }
     } catch (const YAML::Exception& e) {
-        std::cerr << "Error loading elements from YAML: " << e.what() << std::endl;
-        exit(1);
+        // Missing file, parse error, or a missing/mistyped field: surface a
+        // clear, catchable error instead of calling exit() from inside a
+        // loader (which would also abort any in-flight generation).
+        throw std::runtime_error("StarGen: cannot load elements from '" +
+                                 filename + "': " + e.what());
+    }
+    if (loaded == 0) {
+        throw std::runtime_error("StarGen: no elements loaded from '" +
+                                 filename + "' (empty or wrong file?)");
     }
 }
 
-void initGases()
+void initGases(const std::string& path)
 {
-    loadElementsFromYAML("data/elements.yaml");
+    loadElementsFromYAML(path);
 }

--- a/elements.h
+++ b/elements.h
@@ -9,6 +9,9 @@
 
 extern ChemTable gases;
 
-void initGases();
+// Load the element/gas table. `path` defaults to the repo-relative location but
+// can be overridden to make the data location configurable. Throws
+// std::runtime_error (not exit()) if the file is missing, malformed, or empty.
+void initGases(const std::string& path = "data/elements.yaml");
 
 #endif

--- a/main.cpp
+++ b/main.cpp
@@ -1,6 +1,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <exception>
 #include <iostream>
 #include <string>
 
@@ -480,7 +481,14 @@ int main(int argc, char **argv) {
   argc      = ccommand(&argv);
 #endif
 
-  initData();
+  try {
+    initData();
+  } catch (const std::exception& e) {
+    // Data loaders (e.g. the elements YAML) now throw instead of exit()-ing
+    // from deep in the call stack; report cleanly and fail with a non-zero code.
+    std::cerr << e.what() << '\n';
+    return EXIT_FAILURE;
+  }
 
   // Extract program name
   std::string prognam = argv[0];

--- a/orbital_simulator_demo.cpp
+++ b/orbital_simulator_demo.cpp
@@ -11,6 +11,8 @@
 
 #include <iostream>
 #include <iomanip>
+#include <cstdlib>      // for EXIT_FAILURE
+#include <exception>    // for std::exception
 #include "stargen.h"
 #include "StarGenerator.h"
 #include "OrbitalSimulator.h"
@@ -36,19 +38,26 @@ void printPlanetInfo(planet* p, int index) {
 }
 
 int main() {
-    // Initialize global data tables (REQUIRED for generation)
-    initRadii();
-    initGases();
-    initPlanets();
-    initDole();
-    initSolStation();
-    initJimb();
-    initOmegaGalaxy();
-    initRingUniverse();
-    initIC3094();
-    initAndromeda();
-    initStarTrek();
-    initPlanetaryHabitabilityLaboratory();
+    // Initialize global data tables (REQUIRED for generation). The data loaders
+    // (e.g. the elements YAML) throw std::runtime_error on a missing/malformed
+    // file, so fail gracefully instead of letting it escape to std::terminate().
+    try {
+        initRadii();
+        initGases();
+        initPlanets();
+        initDole();
+        initSolStation();
+        initJimb();
+        initOmegaGalaxy();
+        initRingUniverse();
+        initIC3094();
+        initAndromeda();
+        initStarTrek();
+        initPlanetaryHabitabilityLaboratory();
+    } catch (const std::exception& e) {
+        std::cerr << e.what() << '\n';
+        return EXIT_FAILURE;
+    }
 
     std::cout << "================================================\n";
     std::cout << "OrbitalSimulator Non-Invasive Demo\n";

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,6 +3,7 @@ add_executable(stargen_tests
     test_basic.cpp
     enviro_test.cpp
     determinism_threads_test.cpp
+    elements_error_test.cpp
 )
 
 target_link_libraries(stargen_tests PRIVATE

--- a/tests/elements_error_test.cpp
+++ b/tests/elements_error_test.cpp
@@ -1,0 +1,49 @@
+// Error-path contract for the elements YAML loader.
+//
+// loadElementsFromYAML()/initGases() were changed from calling exit() deep in
+// the call stack to THROWING std::runtime_error, so the caller can report and
+// exit cleanly (main.cpp wraps initData() in a try/catch). These tests lock that
+// contract: a future refactor that reverts to exit() — or swallows the throw —
+// will fail here. Each case throws WITHOUT populating the global `gases` table
+// (the throw happens before any addChemicle), so it does not perturb other
+// tests in this binary.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <filesystem>
+#include <fstream>
+#include <stdexcept>
+#include <string>
+#include <system_error>
+
+#include "elements.h"
+
+namespace fs = std::filesystem;
+
+TEST_CASE("initGases throws (not exit) on a missing elements file",
+          "[elements][error]") {
+  REQUIRE_THROWS_AS(initGases("stargen_definitely_missing_elements.yaml"),
+                    std::runtime_error);
+}
+
+TEST_CASE("initGases throws on an empty elements file", "[elements][error]") {
+  const fs::path p = fs::path(STARGEN_TEST_WORKDIR) / "empty_elements.yaml";
+  { std::ofstream(p) << ""; }
+  REQUIRE_THROWS_AS(initGases(p.string()), std::runtime_error);
+  std::error_code ec;
+  fs::remove(p, ec);
+}
+
+TEST_CASE("initGases throws on a non-positive atomic weight",
+          "[elements][error]") {
+  const fs::path p = fs::path(STARGEN_TEST_WORKDIR) / "badweight_elements.yaml";
+  {
+    std::ofstream f(p);
+    f << "- atomic_number: 1\n"
+      << "  symbol: XX\n"
+      << "  atomic_weight: 0.0\n";
+  }
+  REQUIRE_THROWS_AS(initGases(p.string()), std::runtime_error);
+  std::error_code ec;
+  fs::remove(p, ec);
+}

--- a/viewer.cpp
+++ b/viewer.cpp
@@ -12,6 +12,8 @@
 
 #include <iostream>
 #include <cmath>
+#include <cstdlib>      // for EXIT_FAILURE
+#include <exception>    // for std::exception
 #include <vector>
 #include "raylib.h"
 #include "stargen.h"
@@ -313,9 +315,15 @@ void drawUI(const OrbitalStateManager& manager, const ViewState& view,
 }
 
 int main() {
-    // Initialize generation system
+    // Initialize generation system. The data loaders throw std::runtime_error on
+    // a missing/malformed file; fail gracefully instead of std::terminate().
     std::cout << "Initializing stellar system generator...\n";
-    initializeGenerationData();
+    try {
+        initializeGenerationData();
+    } catch (const std::exception& e) {
+        std::cerr << e.what() << '\n';
+        return EXIT_FAILURE;
+    }
 
     // Generate a test system
     std::cout << "Generating stellar system (seed 42)...\n";


### PR DESCRIPTION
## Problem

`loadElementsFromYAML()` called **`exit(1)` from inside the loader** on any YAML error — aborting the whole process from deep in the call stack, with no clean way to report or test, and it would kill in-flight generation if ever invoked off the startup path. It also hardcoded `"data/elements.yaml"` and did no field validation (the card flagged zero `density`/`atomic_weight` feeding downstream div0).

## Fix

- **Throw, don't `exit()`**: on a missing/malformed/empty file, `loadElementsFromYAML` throws `std::runtime_error` with a clear, catchable message. `main()` wraps `initData()` in `try/catch(const std::exception&)` → prints the message and returns `EXIT_FAILURE`.
- **Configurable path**: `initGases(path = "data/elements.yaml")` — the data location is now a parameter; existing callers use the default unchanged.
- **Validate `atomic_weight > 0`** (the genuine div0 source). `density` is intentionally **not** rejected — the shipped table legitimately carries `density: 0.0` for four synthetic elements, so rejecting it would break valid runs.
- **Reject an empty / no-element table** (a run with no gases is broken).
- **All `initGases` callers fail gracefully**: `orbital_demo` and `viewer` wrap their init in `try/catch` too (they previously would `std::terminate()` once the shared function started throwing — caught by adversarial review).
- **New tests** (`tests/elements_error_test.cpp`, 3 cases) lock the throw-contract: missing file, empty file, non-positive atomic weight all `REQUIRE_THROWS_AS(std::runtime_error)`. Each throws before populating the global table, so it doesn't perturb other tests.

## Verification

- **Happy path byte-identical**: the shipped 124-element table loads in the same order/values (validation passes, empty-check never fires); `scripts/verify.sh`: **12/12 ctest pass** (9 + 3 new), incl. `golden_regression` + determinism.
- **Error paths** exit `1` with a clear message (no `terminate()`, no silent `exit`): missing → `cannot load elements from '...': bad file`; empty → `no elements loaded`.
- `orbital_demo` builds clean.

Built/verified with GCC-16 `-O3`. The review (byte-identity + validation lenses) was otherwise clean.

## Scope note

`card-44d34043` also covers **`display.cpp` file-open robustness** (`exit()` in `openCVSorJson`/`refresh_file_stream`, unchecked `open_html_file`/`create_svg_file`, `std::filesystem::path` for path joins). This PR does the **YAML loader** half; the display.cpp half remains as a follow-up on that card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)