### PR TITLE
fix(io): robust display.cpp output (throw on open failure, non-zero exit) — finishes card-44d34043

### DIFF
--- a/display.cpp
+++ b/display.cpp
@@ -723,8 +723,10 @@ void create_svg_file(planet* innermost_planet, std::string path, std::string fil
                      std::string prognam, bool do_moons) {
   performanceMonitor.recordFileOperation("svg_output");
 
-  const std::string the_file_spec =
-      (std::filesystem::path(path) / (file_name + svg_ext)).string();
+  // path already carries a trailing separator (see stargen.cpp), and a plain
+  // concat is byte-identical for every input incl. an absolute -o name (fs::path
+  // operator/ would instead let an absolute file_name override the directory).
+  const std::string the_file_spec = path + file_name + svg_ext;
 
   std::fstream output;
 #ifdef macintosh
@@ -772,8 +774,7 @@ void create_svg_file(planet* innermost_planet, std::string path, std::string fil
  */
 void openCVSorJson(std::string path, std::string the_filename, std::fstream& output) {
   ensure_directory_exists(path);
-  const std::string the_file_spec =
-      (std::filesystem::path(path) / the_filename).string();
+  const std::string the_file_spec = path + the_filename;
 
 #ifdef macintosh
   _fcreator = 'MSIE';
@@ -803,8 +804,7 @@ void refresh_file_stream(std::fstream& output, const std::string& path, const st
                          const std::string& ext) {
   output.close();
 
-  const std::string the_file_spec =
-      (std::filesystem::path(path) / (file_name + ext)).string();
+  const std::string the_file_spec = path + file_name + ext;
 
   output.open(the_file_spec.c_str(), std::fstream::out | std::fstream::app);
   if (!output) {
@@ -829,8 +829,7 @@ void open_html_file(const std::string& system_name, long seed, const std::string
                     const std::string& url_path, const std::string& file_name, const std::string& ext,
                     const std::string& prognam, std::fstream& output) {
   ensure_directory_exists(path);
-  const std::string the_file_spec =
-      (std::filesystem::path(path) / (file_name + ext)).string();
+  const std::string the_file_spec = path + file_name + ext;
   const bool noname = system_name.empty();
 
 #ifdef macintosh

--- a/display.cpp
+++ b/display.cpp
@@ -7,6 +7,7 @@
 #include <iostream>
 #include <nlohmann/json.hpp>
 #include <sstream>
+#include <stdexcept>
 
 #include "PerformanceMonitor.h"
 #include "SimulationContext.h"
@@ -722,9 +723,8 @@ void create_svg_file(planet* innermost_planet, std::string path, std::string fil
                      std::string prognam, bool do_moons) {
   performanceMonitor.recordFileOperation("svg_output");
 
-  std::stringstream ss;
-  ss << path << file_name << svg_ext;
-  std::string the_file_spec = ss.str();
+  const std::string the_file_spec =
+      (std::filesystem::path(path) / (file_name + svg_ext)).string();
 
   std::fstream output;
 #ifdef macintosh
@@ -736,6 +736,10 @@ void create_svg_file(planet* innermost_planet, std::string path, std::string fil
   _fcreator = 'R*ch';
   _ftype    = 'TEXT';
 #endif
+  if (!output) {
+    throw std::runtime_error("StarGen: cannot open SVG file '" + the_file_spec +
+                             "' for writing");
+  }
 
   // Find outermost planet (last in vector)
   planet* outermost_planet = g_sim_context.planets.empty() ? innermost_planet : g_sim_context.planets.back();
@@ -768,12 +772,8 @@ void create_svg_file(planet* innermost_planet, std::string path, std::string fil
  */
 void openCVSorJson(std::string path, std::string the_filename, std::fstream& output) {
   ensure_directory_exists(path);
-  std::string       the_file_spec;
-  std::stringstream ss;
-
-  ss.str("");
-  ss << path << the_filename;
-  the_file_spec = ss.str();
+  const std::string the_file_spec =
+      (std::filesystem::path(path) / the_filename).string();
 
 #ifdef macintosh
   _fcreator = 'MSIE';
@@ -785,7 +785,8 @@ void openCVSorJson(std::string path, std::string the_filename, std::fstream& out
   _ftype    = 'TEXT';
 #endif
   if (!output) {
-    exit(EXIT_FAILURE);
+    throw std::runtime_error("StarGen: cannot open output file '" +
+                             the_file_spec + "' for writing");
   }
   ZoneScoped;
 }
@@ -800,18 +801,15 @@ void openCVSorJson(std::string path, std::string the_filename, std::fstream& out
  */
 void refresh_file_stream(std::fstream& output, const std::string& path, const std::string& file_name,
                          const std::string& ext) {
-  std::string       the_file_spec;
-  std::stringstream ss;
-
   output.close();
 
-  ss.str("");
-  ss << path << file_name << ext;
-  the_file_spec = ss.str();
+  const std::string the_file_spec =
+      (std::filesystem::path(path) / (file_name + ext)).string();
 
   output.open(the_file_spec.c_str(), std::fstream::out | std::fstream::app);
   if (!output) {
-    exit(EXIT_FAILURE);
+    throw std::runtime_error("StarGen: cannot reopen output file '" +
+                             the_file_spec + "' for writing");
   }
 }
 
@@ -831,13 +829,9 @@ void open_html_file(const std::string& system_name, long seed, const std::string
                     const std::string& url_path, const std::string& file_name, const std::string& ext,
                     const std::string& prognam, std::fstream& output) {
   ensure_directory_exists(path);
-  std::string       the_file_spec;
-  bool         noname = system_name.empty();
-  std::stringstream ss;
-
-  ss.str("");
-  ss << path << file_name << ext;
-  the_file_spec = ss.str();
+  const std::string the_file_spec =
+      (std::filesystem::path(path) / (file_name + ext)).string();
+  const bool noname = system_name.empty();
 
 #ifdef macintosh
   _fcreator = 'MSIE';
@@ -849,7 +843,8 @@ void open_html_file(const std::string& system_name, long seed, const std::string
   _ftype    = 'TEXT';
 #endif
   if (!output) {
-    exit(EXIT_FAILURE);
+    throw std::runtime_error("StarGen: cannot open HTML file '" + the_file_spec +
+                             "' for writing");
   }
 
   output << "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\"\n";
@@ -1614,8 +1609,7 @@ void html_thumbnails(planet* innermost_planet, std::fstream& the_file, const std
                      const std::string& file_name, bool details, bool terrestrials, bool int_link,
                      bool do_moons, int graphic_format, bool do_gases) {
   if (!the_file) {
-    std::cout << "We have a serious error!\n";
-    exit(EXIT_FAILURE);
+    throw std::runtime_error("StarGen: thumbnail output stream is not open");
   }
 
   sun the_sun = innermost_planet->getTheSun();

--- a/main.cpp
+++ b/main.cpp
@@ -516,9 +516,11 @@ int main(int argc, char **argv) {
   // Set global flag for backward compatibility
   flags_arg_clone = args.flags_arg;
 
-  // Run the star generation
+  // Run the star generation. Output file-open failures now throw (instead of
+  // exit()-ing from inside display.cpp); report cleanly and fail non-zero.
   ZoneScoped;
-  return stargen(
+  try {
+    return stargen(
     args.action,
     args.flag_char,
     args.path,
@@ -540,7 +542,11 @@ int main(int argc, char **argv) {
     args.out_format,
     args.graphic_format,
     args.num_threads
-  );
+    );
+  } catch (const std::exception& e) {
+    std::cerr << e.what() << '\n';
+    return EXIT_FAILURE;
+  }
 }
 
 /**

--- a/stargen.cpp
+++ b/stargen.cpp
@@ -995,7 +995,9 @@ auto stargen(actions action, const std::string &flag_char, std::string path,
       std::cerr << "\n";  // Clear progress line
     }
     print_summary_statistics();
-    return EXIT_SUCCESS;
+    // A failed output (e.g. an unwritable directory throwing from the display.cpp
+    // open functions) must surface as a non-zero exit, not a silent success.
+    return failed_count > 0 ? EXIT_FAILURE : EXIT_SUCCESS;
   }
 
   // Sequential execution path (fallback for complex cases)


### PR DESCRIPTION
## Problem

Finishes `card-44d34043` (the YAML-loader half landed in #39). `display.cpp`'s output functions handled an open failure badly:
- `create_svg_file` **didn't check the open at all** → silently wrote an empty/no file.
- `openCVSorJson` / `refresh_file_stream` / `open_html_file` (+ the defensive `html_thumbnails` check) called **`exit()` with no message** from deep in the call stack.

## Fix

- All five functions now **throw `std::runtime_error("StarGen: cannot open <fmt> file '<path>' for writing")`** instead of `exit()`/silent-write.
- `main()` wraps the `stargen()` call in `try/catch(const std::exception&)` → `cerr` + `EXIT_FAILURE`. Output runs **serially** (parallel mode defers all output until after the workers join), so the throw is always caught on the main thread.
- The parallel output phase already caught per-system output exceptions and warned; it now **returns `EXIT_FAILURE` when any system failed to output**, so an unwritable directory surfaces as a non-zero exit (the old `exit()` did this by bypassing the catch — without this, the throw conversion would have regressed the exit code to 0 on the multi-system path).

## What this PR deliberately does *not* do

The card suggested `std::filesystem::path` for path joins. I tried it, but `path` already carries a trailing separator upstream (`stargen.cpp` `path.append(DIRSEP)`), so fs::path added no robustness — and its operator/ silently relocates an **absolute** `-o` filename (writes to `/abs` instead of `html//abs`). To preserve byte-identity for every input, `the_file_spec` uses plain string concatenation (identical to the original).

## Verification

- **Byte-identical** vs clean master (both `-O3`): JSON/CSV/HTML/SVG × 3 seeds, **90 files**, identical content + filenames.
- **Error paths** exit `1` with a clear message on a read-only `html/`: `cannot open SVG file 'html/out.svg'` (SVG previously wrote nothing silently), HTML/CSV likewise; verified on **both** the sequential (`-n1`) and parallel (`-n12 -T4`) paths.
- `scripts/verify.sh`: **12/12 ctest pass**; `orbital_demo` builds clean.

Both review rounds (threading/throw-safety, byte-identity, completeness) are now clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error reporting for output file operations—error messages are now displayed instead of silently exiting
  * Fixed exit status handling: the program now returns proper failure codes when output files cannot be opened or written
  * Improved diagnostic feedback for file-related issues

<!-- end of auto-generated comment: release notes by coderabbit.ai -->