### PR TITLE
chore: remove verified-dead code (moongen, mac resource-fork, no-op dtors, dup fn)

### DIFF
--- a/OrbitalSimulator.cpp
+++ b/OrbitalSimulator.cpp
@@ -159,35 +159,3 @@ double OrbitalSimulator::calculateMeanAnomaly(double a, double t, double m_star,
 
     return M;
 }
-
-Vector3 OrbitalSimulator::orbitalToCartesian(double a, double e, double i,
-                                              double omega, double w, double M) const {
-    // This is an alternative implementation (not currently used)
-    // Kept for reference
-
-    // Solve Kepler's equation
-    double E = solveKeplersEquation(M, e);
-
-    // Position in orbital plane
-    double x_orb = a * (std::cos(E) - e);
-    double y_orb = a * std::sqrt(1.0 - e * e) * std::sin(E);
-
-    // Rotation matrices
-    double cos_omega = std::cos(omega);
-    double sin_omega = std::sin(omega);
-    double cos_w = std::cos(w);
-    double sin_w = std::sin(w);
-    double cos_i = std::cos(i);
-    double sin_i = std::sin(i);
-
-    // Transform to 3D
-    double x = (cos_omega * cos_w - sin_omega * sin_w * cos_i) * x_orb +
-               (-cos_omega * sin_w - sin_omega * cos_w * cos_i) * y_orb;
-
-    double y = (sin_omega * cos_w + cos_omega * sin_w * cos_i) * x_orb +
-               (-sin_omega * sin_w + cos_omega * cos_w * cos_i) * y_orb;
-
-    double z = (sin_w * sin_i) * x_orb + (cos_w * sin_i) * y_orb;
-
-    return Vector3(x, y, z);
-}

--- a/OrbitalSimulator.h
+++ b/OrbitalSimulator.h
@@ -142,21 +142,6 @@ private:
     double current_time_ = 0.0;      // Years since epoch
     double time_scale_ = 1.0;        // Speed multiplier
 
-    /**
-     * @brief Calculate position from orbital elements
-     *
-     * Converts Kepler orbital elements to 3D Cartesian coordinates.
-     *
-     * @param a Semi-major axis (AU)
-     * @param e Eccentricity
-     * @param i Inclination (radians)
-     * @param omega Longitude of ascending node (radians)
-     * @param w Argument of periapsis (radians)
-     * @param M Mean anomaly (radians)
-     * @return Position vector in 3D space
-     */
-    Vector3 orbitalToCartesian(double a, double e, double i,
-                               double omega, double w, double M) const;
 
     /**
      * @brief Solve Kepler's equation iteratively

--- a/accrete.cpp
+++ b/accrete.cpp
@@ -764,7 +764,6 @@ auto accrete::dist_planetary_masses(sun &the_sun, long double inner_dust,
   planet *new_moon = nullptr;
   planet *prev_moon = nullptr;
   bool is_seed = false;
-  int i = 0;
 
   if (!the_sun.getIsCircumbinary()) {
     stell_mass_ratio = the_sun.getMass();

--- a/display.cpp
+++ b/display.cpp
@@ -729,15 +729,7 @@ void create_svg_file(planet* innermost_planet, std::string path, std::string fil
   const std::string the_file_spec = path + file_name + svg_ext;
 
   std::fstream output;
-#ifdef macintosh
-  _fcreator = 'MSIE';
-  _ftype    = 'TEXT';
-#endif
   output.open(the_file_spec.c_str(), std::ios::out);
-#ifdef macintosh
-  _fcreator = 'R*ch';
-  _ftype    = 'TEXT';
-#endif
   if (!output) {
     throw std::runtime_error("StarGen: cannot open SVG file '" + the_file_spec +
                              "' for writing");
@@ -776,15 +768,7 @@ void openCVSorJson(std::string path, std::string the_filename, std::fstream& out
   ensure_directory_exists(path);
   const std::string the_file_spec = path + the_filename;
 
-#ifdef macintosh
-  _fcreator = 'MSIE';
-  _ftype    = 'TEXT';
-#endif
   output.open(the_file_spec.c_str(), std::ios::out);
-#ifdef macintosh
-  _fcreator = 'R*ch';
-  _ftype    = 'TEXT';
-#endif
   if (!output) {
     throw std::runtime_error("StarGen: cannot open output file '" +
                              the_file_spec + "' for writing");
@@ -832,15 +816,7 @@ void open_html_file(const std::string& system_name, long seed, const std::string
   const std::string the_file_spec = path + file_name + ext;
   const bool noname = system_name.empty();
 
-#ifdef macintosh
-  _fcreator = 'MSIE';
-  _ftype    = 'TEXT';
-#endif
   output.open(the_file_spec.c_str(), std::fstream::out);
-#ifdef macintosh
-  _fcreator = 'R*ch';
-  _ftype    = 'TEXT';
-#endif
   if (!output) {
     throw std::runtime_error("StarGen: cannot open HTML file '" + the_file_spec +
                              "' for writing");
@@ -2327,11 +2303,6 @@ void celestia_describe_system(planet* innermost_planet, std::string designation,
  * @param is_moon
  * @param planet_num
  */
-#include <format>
-#include <iostream>
-#include <string>
-#include <string_view>
-
 void celestia_describe_world(planet* the_planet, const std::string& designation,
                              const std::string& system_name, long seed, long double inc,
                              long double an, int counter, sun& the_sun, bool is_moon,
@@ -2658,51 +2629,6 @@ void assignDistanceColors(planet* the_planet, double red, double green, double b
 
   std::cout << std::format("\tColor [ {:.2f} {:.2f} {:.2f} ]\n", red, green, blue);
 }
-
-/*
-void moongen_describe_system(planet* innermost_planet, std::string designation,
-std::string system_name, long int seed)
-{
-  planet *the_planet, *moon;
-  sun the_sun = innermost_planet->getTheSun();
-  long tmp;
-  int num_moons = 0;
-  int num_planets = 0;
-  int counter;
-  long double mass = 0;
-  long double total_moon_mass = 0;
-
-  std::cout << "#! /bin/sh -x\n";
-  std::cout << "# Stargen - " << stargen_revision << "; seed=" << seed << "\n";
-  std::cout << "#\n";
-  std::cout << "# Script to generate moons for some planets in the system " <<
-designation << " (" << system_name << ")\n"; std::cout << "#\n";
-
-  counter = 1;
-  for (planet* the_planet : g_sim_context.planets) {
-    mass = the_planet->getMass();
-    total_moon_mass = 0;
-    for (planet* moon : the_planet->moons) {
-      total_moon_mass += moon->getMass();
-    }
-
-    tmp = the_planet->getMinorMoons();
-
-    num_moons += tmp;
-    if (tmp > 0)
-    {
-      num_planets++;
-      std::cout << "moon_orbits -a " << toString(the_planet->getA()) << " -m " <<
-toString(the_planet->getMass() * SUN_MASS_IN_EARTH_MASSES) << " -R " <<
-toString(the_planet->getRadius()) << " -M " << toString(the_sun.getMass()) << "
--n p" << counter << " -N " << tmp << " -U " << toString(total_moon_mass *
-SUN_MASS_IN_EARTH_MASSES) << " -s " << (seed + (counter * 1000)) << " -S " <<
-designation << "\n";
-    }
-    counter++;
-  }
-}
-*/
 
 /**
  * @brief lprint

--- a/display.h
+++ b/display.h
@@ -73,7 +73,6 @@ int random_numberInt(int min, int max);
 void assignTemperatureColors(planet* the_planet, double temp1, double red1, double green1, double blue1,
                              double temp2, double red2, double green2, double blue2);
 void assignDistanceColors(planet* the_planet, double red, double green, double blue);
-void moongen_describe_system(planet *, const std::string&, const std::string&, long);
 void lprint(std::fstream &, bool &, const std::string&);
 auto image_type_string(planet *) -> std::string;
 auto printSpinResonanceFactor(long double) -> std::string;

--- a/main.cpp
+++ b/main.cpp
@@ -475,12 +475,6 @@ bool validateArguments(const CommandLineArgs& args) {
 }
 
 int main(int argc, char **argv) {
-#ifdef macintosh
-  _ftype    = 'TEXT';
-  _fcreator = 'R*ch';
-  argc      = ccommand(&argv);
-#endif
-
   try {
     initData();
   } catch (const std::exception& e) {

--- a/stargen.cpp
+++ b/stargen.cpp
@@ -1282,9 +1282,6 @@ auto stargen(actions action, const std::string &flag_char, std::string path,
           celestia_describe_system(innermost_planet, designation, system_name,
                                    flag_seed, sys_inc, sys_an, do_moons);
           break;
-          /*case ffMOONGEN:
-            moongen_describe_system(innermost_planet, designation, system_name,
-            flag_seed); break;*/
       }
       if (habitable > 1 && ((flag_verbose & 0x0001) != 0)) {
         std::cerr << "System " << flag_seed << " - " << system_name << " (-s"

--- a/stargen.h
+++ b/stargen.h
@@ -47,7 +47,6 @@ enum {
   ffHTML,
   ffTEXT,
   ffCELESTIA,
-  ffMOONGEN,
   ffCSV,
   ffJSON,
   ffCSVdl,

--- a/structs.cpp
+++ b/structs.cpp
@@ -98,21 +98,7 @@ star::star(star2& data) {
  * @brief Destroy the star::star object
  * 
  */
-star::~star() {
-  luminosity = 0;
-  mass = 0;
-  eff_temp = 0;
-  spec_type = "";
-  mass2 = 0;
-  eccentricity = 0;
-  distance = 0;
-  inc = 0;
-  an = 0;
-  desig = "";
-  in_celestia = false;
-  name = "";
-  isCircumbinary = false;
-}
+star::~star() {}
 
 /**
  * @brief Calculate Luminosity
@@ -619,26 +605,7 @@ Chemical::Chemical(const Chemical& rhs) : num(rhs.num), symbol(rhs.symbol), html
 }
 
 /// @brief 
-Chemical::~Chemical() {
-  num = 0;
-  symbol = "";
-  htmlSymbol = "";
-  name = "";
-  weight = 0;
-  melt = 0;
-  boil = 0;
-  density = 0;
-  pzero = 0;
-  c = 0;
-  n = 0;
-  abunde = 0;
-  abunds = 0;
-  reactivity = 0;
-  maxIpp = 0;
-  minIpp = 0;
-  nameSpaces = 0;
-  symbolSpaces = 0;
-}
+Chemical::~Chemical() {}
 
 
 
@@ -1064,50 +1031,6 @@ planet::planet(int n, long double a2, long double e2, long double t, bool gg,
 }
 
 planet::~planet() {
-  a = 0;
-  e = 0;
-  axialTilt = 0;
-  gasGiant = false;
-  dustMass = 0;
-  gasMass = 0;
-  imf = 0;
-  rmf = 0;
-  cmf = 0;
-  moonA = 0;
-  moonE = 0;
-  coreRadius = 0;
-  radius = 0;
-  orbitZone = 0;
-  density = 0;
-  orbPeriod = 0;
-  day = 0;
-  resonantPeriod = false;
-  escVelocity = 0;
-  surfAccel = 0;
-  surfGrav = 0;
-  rmsVelocity = 0;
-  molecWeight = 0;
-  volatileGasInventory = 0;
-  surfPressure = 0;
-  greenhouseEffect = false;
-  boilPoint = 0;
-  albedo = 0;
-  exosphericTemp = 0;
-  estimatedTemp = 0;
-  estimatedTerrTemp = 0;
-  surfTemp = 0;
-  greenhsRise = 0;
-  highTemp = 0;
-  lowTemp = 0;
-  maxTemp = 0;
-  minTemp = 0;
-  hydrosphere = 0;
-  cloudCover = 0;
-  iceCover = 0;
-  inclination = 0;
-  ascendingNode = 0;
-  longitudeOfPericenter = 0;
-  meanLongitude = 0;
   atmosphere.clear();
 
   // Single-source moon ownership. The `moons` vector and the legacy
@@ -1603,13 +1526,7 @@ dust::dust() : innerEdge(0), outerEdge(0), dustPresent(true), gasPresent(true) {
   
 }
 
-dust::~dust() {
-  innerEdge = 0;
-  outerEdge = 0;
-  dustPresent = false;
-  gasPresent = false;
-  // next_band = NULL;
-}
+dust::~dust() {}
 
 auto dust::getDustPresent() const -> bool { return dustPresent; }
 


### PR DESCRIPTION
## Summary

Removes dead code flagged by `card-3058109c`. **+3 / −219** across 9 files. Every item was individually verified unreferenced / never-compiled before removal, and the result is **byte-identical output**.

## Removed

- **macintosh resource-fork stamping** — the `#ifdef macintosh` `_fcreator`/`_ftype`/`ccommand` blocks (display.cpp ×6 + main.cpp). The `macintosh` macro is never defined on the GCC-16/Linux-only build (the bodies reference symbols declared nowhere), so they were always preprocessed out.
- **The commented-out moongen path** — the `/* */` `moongen_describe_system` definition (display.cpp), its declaration (display.h), the commented-out `case` (stargen.cpp), and the now-unused `ffMOONGEN` enum value (stargen.h). No live caller; `ffMOONGEN` was never assigned to `out_format`. Renumbering the other `ff*`/`gf*` values is safe — they're only compared by name, never serialized or array-indexed.
- **No-op scalar/string zeroing in destructors** — `star`/`Chemical`/`dust` dtors (now empty) and the scalar block of `planet::~planet()`. **`planet`'s moon-ownership cleanup tail is kept.**
- **The unused duplicate `OrbitalSimulator::orbitalToCartesian`** (def + decl) — zero callers; duplicated the live inline math in `updatePositions()`.
- **A redundant mid-file `#include` block** in display.cpp (already at the top).
- **A shadowed/unused `int i`** in `accrete::dist_planetary_masses`.

## Deliberately *not* removed

The accrete **NAN-sentinel locals** the audit flagged: per-item verification found every one is written-then-read (defensive init, not dead). `ring_universe2.cpp` was already deleted in #37.

## Verification

- **Byte-identical** vs clean master (both `-O3`): JSON/CSV/CSVdl/HTML/SVG × 3 seeds (93 files) + text + CELESTIA (path-normalized) — **97 comparisons, 0 diffs**.
- `scripts/verify.sh`: **12/12 ctest pass**; `stargen` + `orbital_demo` + `stargen_tests` build clean.
- Gated by a per-item verification pass and a 2-lens adversarial review (over-deletion/dangling-refs + byte-identity/behavior) — both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)