### PR TITLE
refactor: de-duplicate ESI sub-indices + consolidate acceleration constants

### DIFF
--- a/const.h
+++ b/const.h
@@ -105,6 +105,20 @@ constexpr double CM_PER_METER = 100.0;
 constexpr double MILLIBARS_PER_BAR = 1000.00;
 
 constexpr double GRAV_CONSTANT = 6.672E-8;
+
+// SI-unit physical constants used by the enviro.cpp acceleration helpers. These
+// are the EXACT values those functions previously redefined locally, kept
+// verbatim so generated output stays byte-identical. They intentionally differ
+// in precision and/or unit from the CGS-family constants above (e.g. GRAV_CONSTANT
+// is CGS; SOLAR_MASS_IN_KILOGRAMS is the more-precise 1.98892E30) -- unifying on
+// the precise values would change output and is a separate, deliberate change.
+constexpr double GRAV_CONSTANT_SI        = 6.67430e-11; // m^3 kg^-1 s^-2
+constexpr double SOLAR_MASS_IN_KG_APPROX = 1.989e30;    // kg
+constexpr double EARTH_MASS_IN_KG_APPROX = 5.97e24;     // kg
+constexpr double MEAN_EARTH_RADIUS_KM    = 6371.0;      // km (mean)
+constexpr double MEAN_EARTH_RADIUS_M     = 6.371e6;     // m  (mean)
+constexpr double EARTH_GRAVITY_M_S2      = 9.80665;     // m/s^2
+
 constexpr double MOLAR_GAS_CONST = 8314.41;
 constexpr double K = 50.0;
 constexpr double B = 1.2E-5;

--- a/display.cpp
+++ b/display.cpp
@@ -2092,10 +2092,13 @@ static void html_write_additional_properties(planet* the_planet, std::fstream& t
                             the_planet->getCloudCover() * 100.0, the_planet->getIceCover() * 100.0);
   }
 
-  long double esir = calcEsiHelper(convert_km_to_eu(the_planet->getRadius()), 1.0, 0.57);
-  long double esid = calcEsiHelper(the_planet->getDensity() / EARTH_DENSITY, 1.0, 1.07);
-  long double esiv = calcEsiHelper((the_planet->getEscVelocity() / CM_PER_KM) / 11.186, 1.0, 0.70);
-  long double esit = calcEsiHelper(the_planet->getSurfTemp(), EARTH_AVERAGE_KELVIN, 5.58);
+  // Sub-indices come from the single calcEsiComponents() source (the headline
+  // ESI cell below uses the_planet->getEsi(), itself the product of these).
+  EsiComponents esi_c = calcEsiComponents(the_planet);
+  long double esir = esi_c.r;
+  long double esid = esi_c.d;
+  long double esiv = esi_c.v;
+  long double esit = esi_c.t;
 
   the_file << std::format(R"(
 <tr><th>Earth Similarity Index (ESI)</th>

--- a/enviro.cpp
+++ b/enviro.cpp
@@ -546,11 +546,10 @@ auto acceleration(long double mass, long double radius) -> long double {
 }
 
 auto acceleration(planet *the_planet) -> long double {
-    const long double G = 6.67430e-11;  // gravitational constant in m^3 kg^-1 s^-2
-    const long double SOLAR_MASS_KG = 1.989e30;  // kg
-    const long double EARTH_MASS_KG = 5.97e24;   // kg
-    const long double EARTH_RADIUS_KM = 6371.0;  // km
-    const long double EARTH_GRAVITY_CM_S2 = 980.665;  // cm/s^2
+    const long double SOLAR_MASS_KG = SOLAR_MASS_IN_KG_APPROX;  // kg
+    const long double EARTH_MASS_KG = EARTH_MASS_IN_KG_APPROX;  // kg
+    const long double EARTH_RADIUS_KM = MEAN_EARTH_RADIUS_KM;   // km
+    const long double EARTH_GRAVITY_CM_S2 = EARTH_ACCELERATION; // cm/s^2 (980.665)
 
     // Convert planet mass to Earth masses
     long double mass_earth_masses = the_planet->getMass() * (SOLAR_MASS_KG / EARTH_MASS_KG);
@@ -600,10 +599,10 @@ auto acceleration(planet *the_planet) -> long double {
 }
 
 auto acceleration_oblateness_refinement(planet *the_planet) -> long double {
-  const long double G              = 6.67430e-11;  // gravitational constant in m^3 kg^-1 s^-2
-  const long double EARTH_MASS     = 5.97e24;      // kg
-  const long double EARTH_RADIUS_M = 6.371e6;      // meters (Earth's radius)
-  const long double EARTH_GRAVITY  = 9.80665;      // m/s^2
+  const long double G              = GRAV_CONSTANT_SI;        // m^3 kg^-1 s^-2
+  const long double EARTH_MASS     = EARTH_MASS_IN_KG_APPROX; // kg
+  const long double EARTH_RADIUS_M = MEAN_EARTH_RADIUS_M;     // meters (mean)
+  const long double EARTH_GRAVITY  = EARTH_GRAVITY_M_S2;      // m/s^2
 
   // Constants for transition masses
   const long double ROCKY_TRANSITION_MASS_KG     = 10.0 * EARTH_MASS;   // 10 Earth masses
@@ -611,7 +610,7 @@ auto acceleration_oblateness_refinement(planet *the_planet) -> long double {
 
   // Convert planet mass to kilograms
   long double mass_kg = (the_planet->getDustMass() + the_planet->getGasMass()) *
-                        1.989e30;                   // Convert solar masses to kg
+                        SOLAR_MASS_IN_KG_APPROX;    // Convert solar masses to kg
   long double radius_km = the_planet->getRadius();  // Equatorial radius in km
 
   // Check if radius and mass are valid
@@ -2783,16 +2782,17 @@ auto calcEsiHelper(long double value, long double ref_value,
   return std::pow(1.0 - fabs((value - ref_value) / (value + ref_value)), weight / n);
 }
 
+auto calcEsiComponents(planet *the_planet) -> EsiComponents {
+  return {
+      calcEsiHelper(convert_km_to_eu(the_planet->getRadius()), 1.0, 0.57),
+      calcEsiHelper(the_planet->getDensity() / EARTH_DENSITY, 1.0, 1.07),
+      calcEsiHelper((the_planet->getEscVelocity() / CM_PER_KM) / 11.186, 1.0, 0.70),
+      calcEsiHelper(the_planet->getSurfTemp(), EARTH_AVERAGE_KELVIN, 5.58)};
+}
+
 auto calcEsi(planet *the_planet) -> long double {
-  long double esir =
-      calcEsiHelper(convert_km_to_eu(the_planet->getRadius()), 1.0, 0.57);
-  long double esid =
-      calcEsiHelper(the_planet->getDensity() / EARTH_DENSITY, 1.0, 1.07);
-  long double esiv = calcEsiHelper(
-      (the_planet->getEscVelocity() / CM_PER_KM) / 11.186, 1.0, 0.70);
-  long double esit =
-      calcEsiHelper(the_planet->getSurfTemp(), EARTH_AVERAGE_KELVIN, 5.58);
-  return esir * esid * esiv * esit;
+  EsiComponents c = calcEsiComponents(the_planet);
+  return c.r * c.d * c.v * c.t;
 }
 
 auto calcSphHelper(long double min, long double max, long double opt,

--- a/enviro.h
+++ b/enviro.h
@@ -82,6 +82,13 @@ auto is_habitable_optimistic(planet *) -> bool;
 auto calcHzd(planet *) -> long double;
 auto calcHzc(planet *) -> long double;
 auto calcHza(planet *) -> long double;
+// The four Earth-Similarity-Index sub-indices (radius, density, escape velocity,
+// surface temperature). calcEsi() multiplies them; display.cpp shows them
+// individually, so both share the single calcEsiComponents() source.
+struct EsiComponents {
+  long double r, d, v, t;
+};
+auto calcEsiComponents(planet *) -> EsiComponents;
 auto calcEsi(planet *) -> long double;
 auto calcSph(planet *) -> long double;
 auto calcEsiHelper(long double value, long double ref_value, long double weight,long double n = 4) -> long double;


### PR DESCRIPTION
## Summary

`card-8dbca542`. Two **byte-identical** cleanups, +47/−23 across 4 files.

### ESI — single source for the sub-indices
The four Earth-Similarity-Index sub-indices were computed in two places: `calcEsi` (enviro.cpp) returns only their *product*, and `display.cpp` recomputed them for its HTML debug comment. Added **`calcEsiComponents()`** returning the four sub-indices; `calcEsi` multiplies them and `display.cpp` reads them — one source.

> A naive "just call `calcEsi()`" (as the card's stale framing suggested) would have **dropped the sub-indices and changed output** — `calcEsi` returns only the product. The headline ESI cell already came from `getEsi()` (= the product), so it was never the duplication.

### Constants — consolidate the local SI redefinitions
`acceleration()` / `acceleration_oblateness_refinement()` redefined `G` / solar-mass / Earth-mass / Earth-radius / Earth-gravity as **local SI literals** (in a CGS file). Now named once in `const.h` (`GRAV_CONSTANT_SI`, `SOLAR_MASS_IN_KG_APPROX`, `EARTH_MASS_IN_KG_APPROX`, `MEAN_EARTH_RADIUS_KM`/`_M`, `EARTH_GRAVITY_M_S2`) with the **exact** current values; deduped the solar-mass literal shared by both functions; reused the existing **`EARTH_ACCELERATION`** for the one exact match (980.665 cm/s²); and **deleted a dead unused `G`** in `acceleration()`.

> **Unit-mix flag (the card's concern):** these SI values intentionally differ in precision/unit from the existing CGS constants (e.g. `SOLAR_MASS_IN_KILOGRAMS` is the more-precise `1.98892E30`). They're kept **verbatim** and named `*_APPROX`/`_SI` so the discrepancy is *visible*; switching to the precise values would change output and is left as a separate, deliberate decision. Locals stay `long double` (initialised from the new `double` constants) so arithmetic precision is unchanged.

**Left for a follow-up (low value):** naming the `set_temp_range` structural literals — the `*_DENSITY_FACTOR`/`fudge_factor` are already named locals.

## Verification

- **Byte-identical** vs clean master (both `-O3`): JSON/CSV/HTML × 5 seeds (12345/777/42/1/99999), **85 files, 0 diffs** — full-precision JSON exercises the gravity→habitability cascade these constants feed; HTML carries the ESI cell + sub-index comment.
- `scripts/verify.sh`: **12/12 ctest pass**.
- Gated by an investigation pass (which caught the calcEsi "returns only the product" trap and the per-constant unit mismatches) + a 2-lens adversarial review (ESI + constants), both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)