### PR TITLE
Revert LBP disk profile (#44): it produced brown-dwarf-mass planets

### DIFF
--- a/accrete.cpp
+++ b/accrete.cpp
@@ -869,24 +869,8 @@ auto accrete::dist_planetary_masses(sun &the_sun, long double inner_dust,
         std::cerr << "Injecting protoplanet at " << toString(a) << " AU.\n";
       }
 
-      // Lynden-Bell & Pringle (1974) self-similar disk, as the volume density
-      // consistent with StarGen's 4*pi*a^2 shell integral. The swept mass per
-      // unit radius dM/da ~ a^2*rho(a) is made to follow the LBP surface-density
-      // mass distribution 2*pi*a*Sigma(a), Sigma ~ (a/Rc)^-gamma exp(-(a/Rc)^(2-gamma)),
-      // which gives rho(a) ~ a^-(1+gamma) exp(-(a/Rc)^(2-gamma)). Normalized to
-      // the previous Dole profile's value at a = 1 AU so magnitudes (and the
-      // gas-capture K-law in collect_dust) stay comparable. See
-      // research/modern/03-disk-structure-and-snowline.md.
-      {
-        const long double rho_ref =
-            dust_density_coeff * sqrt(stell_mass_ratio) * exp(-ALPHA);
-        const long double shape =
-            std::pow(a, -(1.0 + DISK_GAMMA)) *
-            exp(-std::pow(a / DISK_R_C, 2.0 - DISK_GAMMA));
-        const long double shape_ref =
-            exp(-std::pow(1.0 / DISK_R_C, 2.0 - DISK_GAMMA));  // a=1 -> a^-(1+g)=1
-        dust_density = rho_ref * shape / shape_ref;
-      }
+      dust_density = dust_density_coeff * sqrt(stell_mass_ratio) *
+                     exp(-ALPHA * std::pow(a, 1.0 / NDENSITY));
       crit_mass = critical_limit(a, e, stell_luminosity_ratio);
       if (total_mass == PROTOPLANET_MASS && is_seed == false) {
         // std::cout << "test1\n";

--- a/const.h
+++ b/const.h
@@ -125,13 +125,6 @@ constexpr double B = 1.2E-5;
 constexpr double DUST_DENSITY_COEFF = 2.0E-3;
 constexpr double ALPHA = 5.0;
 constexpr double NDENSITY = 3.0;
-// Lynden-Bell & Pringle (1974) self-similar disk profile (modern ALMA-standard
-// shape). gamma = inner power-law slope (~1.0), R_C = characteristic radius (AU)
-// where the exponential taper provides a physical outer truncation. Used as the
-// volume-density analog consistent with the 4*pi*a^2 shell integral in
-// accrete::collect_dust. See research/modern/03-disk-structure-and-snowline.md.
-constexpr double DISK_GAMMA = 1.0;
-constexpr double DISK_R_C = 30.0;
 constexpr double J = 1.46E-19;
 // Define INCREDIBLY_LARGE_NUMBER based on whether HUGE_VAL is available or not
 #ifdef HUGE_VAL

--- a/scripts/validate_population.py
+++ b/scripts/validate_population.py
@@ -100,10 +100,12 @@ def analyze(systems: list[dict], star_mass: float) -> dict:
     adj_pairs = 0
     hill_spacings: list[float] = []
     period_ratios: list[float] = []
+    total_mass_earth: list[float] = []
 
     for sys_ in systems:
         planets = sorted(sys_.get("planets", []), key=lambda p: p["Distance"])
         counts.append(len(planets))
+        total_mass_earth.append(sum(p["Total Mass"] for p in planets) * SUN_MASS_IN_EARTH)
         det = 0
         for p in planets:
             e = p["Eccentricity"]
@@ -146,6 +148,7 @@ def analyze(systems: list[dict], star_mass: float) -> dict:
 
     return {
         "n_systems": len(systems),
+        "mean_total_mass_earth": sum(total_mass_earth) / len(total_mass_earth) if total_mass_earth else float("nan"),
         "mean_planets": sum(counts) / len(counts) if counts else float("nan"),
         "mean_planets_detcut": sum(det_counts) / len(det_counts) if det_counts else float("nan"),
         "sigma_e_all": rms(all_e),
@@ -185,6 +188,7 @@ def report(m: dict) -> None:
     print()
     print("COUNTS / RADII (intrinsic vs detection-limited; see caveat):")
     line("mean planets / star (intrinsic)", m["mean_planets"], "(StarGen emits ALL bodies)")
+    line("mean total planet mass (Earths)", m["mean_total_mass_earth"], "scales ~M*^1.8 (Ansdell 2016)")
     line("mean planets / star (P<400d,R>1Re)", m["mean_planets_detcut"], "~1.4-2.0 (Hsu 2019)")
     print(f"  small-planet radius bins (Re):  1.0-1.5: {m['radius_small_count']:<5}"
           f" 1.5-2.0(valley): {m['radius_valley_count']:<5} 2.0-3.0: {m['radius_subnep_count']}")

--- a/tests/golden/stargen_seed_12345.txt
+++ b/tests/golden/stargen_seed_12345.txt
@@ -6,20 +6,23 @@ Age: 2.9435951718504091879 billion years	(7.2188917568565470887 billion left on 
 Habitable ecosphere radius: 1.1195233204889958 AU
 
 Planets present at:
-1	0.32929052848992333358 AU	0.14537575704507287844 EM	o
-2	0.43925180315611207356 AU	0.0092920362712675071835 EM	.
-3	0.4761873177472786985 AU	0.114339129025434097 EM	o
-4	0.61296553499806550697 AU	0.8928633727415372686 EM	+
-5	0.68775488031796824204 AU	0.077546711964506732146 EM	.
-6	0.928545262202229191 AU	0.15829092604981142062 EM	o
-7	1.2702814717675298573 AU	0.3174172187865715076 EM	o
-8	1.5232573688759141364 AU	1.2294538870346133282 EM	o
-9	2.2760469761771999595 AU	19.166302541856519605 EM	o
-10	3.0651501624522978849 AU	0.7235304979306091057 EM	o
-11	4.4095270134381198187 AU	0.8718445036575049511 EM	o
-12	6.7269341104082616503 AU	2328.1180481823469184 EM	o
-13	18.883882511388664091 AU	565.39723426850745885 EM	o
-14	44.540689250152073683 AU	22807.018340524934711 EM	o
+1	0.32929052848992333358 AU	0.056881742499426778893 EM	.
+2	0.43925180315611207356 AU	0.004963935400002713156 EM	.
+3	0.45964674491661890242 AU	0.006096406370978955241 EM	.
+4	0.4778886148734016992 AU	0.06119851657504032232 EM	.
+5	0.61296553499806550697 AU	0.6397642960040522841 EM	o
+6	0.68775488031796824204 AU	0.06394021786138123063 EM	.
+7	0.928545262202229191 AU	0.15260228929772928803 EM	o
+8	1.2702814717675298573 AU	0.34868708360437104053 EM	o
+9	1.5232573688759141364 AU	1.3341239377847115686 EM	o
+10	2.2760469761771999595 AU	32.705540882521099498 EM	o
+11	3.0651501624522978849 AU	0.58856339012300186014 EM	o
+12	4.4095270134381198187 AU	1.8251045386066755698 EM	o
+13	6.726454872456255304 AU	652.3035700326716637 EM	o
+14	13.648180577000076059 AU	0.7490587732460501819 EM	o
+15	18.997848568563493705 AU	5.61696320492433811 EM	o
+16	26.744272453248485406 AU	2.3835069451012859004 EM	o
+17	44.658659885913400953 AU	0.90120455136914300455 EM	o
 
 
 
@@ -27,21 +30,21 @@ Planet 1
 Planet is tidally locked with one face to star.
    Distance from primary star:	0.32929052848992333358 AU
    Eccentricity of orbit:	0.044021088632346591423
-   Length of year:		69.018596330083381386 days
-   Length of day:		1656.4463119220011533 hours
-   Mass:			0.14537575704507287844 Earth masses
-   Surface gravity:		0.5562948194063053883 Earth gees
+   Length of year:		69.0186055070339832 days
+   Length of day:		1656.4465321688155968 hours
+   Mass:			0.056881742499426778893 Earth masses
+   Surface gravity:		0.3614652160721370886 Earth gees
    Surface pressure:		0 Earth atmospheres
    Surface temperature:		192.70055394925742576 degrees Celcius
    Boiling point of water:	-273.14999999999997726 degrees Celcius
    Hydrosphere percentage:	0%
    Cloud cover percentage:	0%
    Ice cover percentage:	0%
-   Equatorial radius:		3473.5593614950823935 Km
-   Density:			4.9493138224796886177 grams/cc
-   Escape Velocity:		5.777428008474003291 Km/sec
-   Molecular weight retained:	186.80312324894243273 and above
-   Surface acceleration:	545.5388590730844534 cm/sec2
+   Equatorial radius:		2695.469540671665163 Km
+   Density:			4.144258000046801264 grams/cc
+   Escape Velocity:		4.1024674329364200823 Km/sec
+   Molecular weight retained:	369.50032419051478963 and above
+   Surface acceleration:	354.47628611938230486 cm/sec2
    Axial tilt:			0 degrees
    Planetary albedo:		0.07000000000000000666
 
@@ -50,258 +53,319 @@ Planet 2
 Planet is tidally locked with one face to star.
    Distance from primary star:	0.43925180315611207356 AU
    Eccentricity of orbit:	0.0154299804187318679595
-   Length of year:		106.332905795131553994 days
-   Length of day:		2551.9897390831572959 hours
-   Mass:			0.0092920362712675071835 Earth masses
-   Surface gravity:		0.14387171337807496034 Earth gees
+   Length of year:		106.3329064866177643 days
+   Length of day:		2551.9897556788263433 hours
+   Mass:			0.004963935400002713156 Earth masses
+   Surface gravity:		0.10786277766144842308 Earth gees
    Surface pressure:		0 Earth atmospheres
    Surface temperature:		130.19758344239704684 degrees Celcius
    Boiling point of water:	-273.14999999999997726 degrees Celcius
    Hydrosphere percentage:	0%
    Cloud cover percentage:	0%
    Ice cover percentage:	0%
-   Equatorial radius:		1680.6726206569700612 Km
-   Density:			2.792792690624055914 grams/cc
-   Escape Velocity:		2.0998573660323637887 Km/sec
-   Molecular weight retained:	831.3396685360815579 and above
-   Surface acceleration:	141.08995379990987575 cm/sec2
+   Equatorial radius:		1418.7067835930604833 Km
+   Density:			2.4804207927771987465 grams/cc
+   Escape Velocity:		1.6704852615393983433 Km/sec
+   Molecular weight retained:	1311.3340008579400529 and above
+   Surface acceleration:	105.777250855364313896 cm/sec2
    Axial tilt:			0 degrees
    Planetary albedo:		0.07000000000000000666
 
 
 Planet 3
 Planet is tidally locked with one face to star.
-   Distance from primary star:	0.4761873177472786985 AU
-   Eccentricity of orbit:	0.014816203367232950658
-   Length of year:		120.02287379568725074 days
-   Length of day:		2880.5489710964940178 hours
-   Mass:			0.114339129025434097 Earth masses
-   Surface gravity:		0.5483762094393534474 Earth gees
+   Distance from primary star:	0.45964674491661890242 AU
+   Eccentricity of orbit:	0.025185506734100728422
+   Length of year:		113.8239461776287372 days
+   Length of day:		2731.7747082630896929 hours
+   Mass:			0.006096406370978955241 Earth masses
+   Surface gravity:		0.14260381099132767619 Earth gees
    Surface pressure:		0 Earth atmospheres
-   Surface temperature:		114.239034602023593834 degrees Celcius
+   Surface temperature:		121.14760700799104143 degrees Celcius
    Boiling point of water:	-273.14999999999997726 degrees Celcius
    Hydrosphere percentage:	0%
    Cloud cover percentage:	0%
    Ice cover percentage:	0%
-   Equatorial radius:		3192.1973696546750303 Km
-   Density:			5.015368543480571154 grams/cc
-   Escape Velocity:		5.344763372662301408 Km/sec
-   Molecular weight retained:	98.694740446960414565 and above
-   Surface acceleration:	537.7733554298435285 cm/sec2
+   Equatorial radius:		1445.449710184329556 Km
+   Density:			2.880329201349892615 grams/cc
+   Escape Velocity:		1.8340508450878140866 Km/sec
+   Molecular weight retained:	892.42246401410229983 and above
+   Surface acceleration:	139.84656630581035039 cm/sec2
    Axial tilt:			0 degrees
    Planetary albedo:		0.07000000000000000666
 
 
 Planet 4
-   Distance from primary star:	0.61296553499806550697 AU
-   Eccentricity of orbit:	0.061661145837307691873
-   Length of year:		175.28746508781908796 days
-   Length of day:		99.579960492362779384 hours
-   Mass:			0.8928633727415372686 Earth masses
-   Surface gravity:		1.4231497002171530252 Earth gees
-   Surface pressure:		134.81874829246277114 Earth atmospheres GREENHOUSE EFFECT
-   Surface temperature:		760.5688519311487906 degrees Celcius
-   Boiling point of water:	312.54286654803274814 degrees Celcius
+Planet is tidally locked with one face to star.
+   Distance from primary star:	0.4778886148734016992 AU
+   Eccentricity of orbit:	0.016789484131539109818
+   Length of year:		120.66667476436553169 days
+   Length of day:		2896.0001943447727606 hours
+   Mass:			0.06119851657504032232 Earth masses
+   Surface gravity:		0.4153550613440611405 Earth gees
+   Surface pressure:		0 Earth atmospheres
+   Surface temperature:		113.548861778586740456 degrees Celcius
+   Boiling point of water:	-273.14999999999997726 degrees Celcius
    Hydrosphere percentage:	0%
-   Cloud cover percentage:	100%
+   Cloud cover percentage:	0%
    Ice cover percentage:	0%
-   Equatorial radius:		5552.482192205475884 Km
-   Density:			7.442188446664601477 grams/cc
-   Escape Velocity:		11.324651003264922183 Km/sec
-   Molecular weight retained:	13.312962833908546514 and above
-   Surface acceleration:	1395.6331007634543196 cm/sec2
-   Axial tilt:			73.02984193694150861 degrees
-   Planetary albedo:		0.52000000000000001776
+   Equatorial radius:		2690.7952817807982593 Km
+   Density:			4.4820438482206959277 grams/cc
+   Escape Velocity:		4.2589842033388104754 Km/sec
+   Molecular weight retained:	153.26608034227349663 and above
+   Surface acceleration:	407.32417123297370326 cm/sec2
+   Axial tilt:			0 degrees
+   Planetary albedo:		0.07000000000000000666
 
 
 Planet 5
 Planet is tidally locked with one face to star.
+   Distance from primary star:	0.61296553499806550697 AU
+   Eccentricity of orbit:	0.061661145837307691873
+   Length of year:		175.28753174684774581 days
+   Length of day:		4206.9007619243458995 hours
+   Mass:			0.6397642960040522841 Earth masses
+   Surface gravity:		1.2221995328418504867 Earth gees
+   Surface pressure:		0 Earth atmospheres
+   Surface temperature:		16.657231911023904714 degrees Celcius
+   Boiling point of water:	-273.14999999999997726 degrees Celcius
+   Hydrosphere percentage:	0%
+   Cloud cover percentage:	99.22926533707410606%
+   Ice cover percentage:	0%
+   Equatorial radius:		5073.074741032417774 Km
+   Density:			6.9917098191855810074 grams/cc
+   Escape Velocity:		10.028830233224036638 Km/sec
+   Molecular weight retained:	16.917413003185117273 and above
+   Surface acceleration:	1198.5683048743532632 cm/sec2
+   Axial tilt:			0 degrees
+   Planetary albedo:		0.516531694016833495
+
+
+Planet 6
+Planet is tidally locked with one face to star.
    Distance from primary star:	0.68775488031796824204 AU
    Eccentricity of orbit:	0.03205333361981198482
-   Length of year:		208.32808867211535776 days
-   Length of day:		4999.8741281307685864 hours
-   Mass:			0.077546711964506732146 Earth masses
-   Surface gravity:		0.46351890746277276282 Earth gees
+   Length of year:		208.32809293116259253 days
+   Length of day:		4999.8742303479022207 hours
+   Mass:			0.06394021786138123063 Earth masses
+   Surface gravity:		0.47654443242343379138 Earth gees
    Surface pressure:		0 Earth atmospheres
    Surface temperature:		49.193854951662501662 degrees Celcius
    Boiling point of water:	-273.14999999999997726 degrees Celcius
    Hydrosphere percentage:	0%
    Cloud cover percentage:	0%
    Ice cover percentage:	0%
-   Equatorial radius:		2868.0075137842850426 Km
-   Density:			4.6902901742003685957 grams/cc
-   Escape Velocity:		4.643735361870441702 Km/sec
-   Molecular weight retained:	62.245676549222317533 and above
-   Surface acceleration:	454.5567693869800346 cm/sec2
+   Equatorial radius:		2655.043230257542212 Km
+   Density:			4.874572112695911144 grams/cc
+   Escape Velocity:		4.3825529090095747963 Km/sec
+   Molecular weight retained:	65.53317782822574544 and above
+   Surface acceleration:	467.33044582252668167 cm/sec2
    Axial tilt:			0 degrees
    Planetary albedo:		0.07000000000000000666
 
 
-Planet 6
+Planet 7
    Distance from primary star:	0.928545262202229191 AU
    Eccentricity of orbit:	0.049940742480315653017
-   Length of year:		326.81491850041389863 days
-   Length of day:		31.266200648703935689 hours
-   Mass:			0.15829092604981142062 Earth masses
-   Surface gravity:		0.6673100565044594442 Earth gees
+   Length of year:		326.81492129378319358 days
+   Length of day:		32.12745260442253654 hours
+   Mass:			0.15260228929772928803 Earth masses
+   Surface gravity:		0.6186394958563824337 Earth gees
    Surface pressure:		0 Earth atmospheres
    Surface temperature:		4.2680384392294286044 degrees Celcius
    Boiling point of water:	-273.14999999999997726 degrees Celcius
    Hydrosphere percentage:	0%
    Cloud cover percentage:	0%
    Ice cover percentage:	0%
-   Equatorial radius:		3451.3021550380185216 Km
-   Density:			5.49394427733527986 grams/cc
-   Escape Velocity:		6.0480090039421780966 Km/sec
-   Molecular weight retained:	19.78340126932666852 and above
-   Surface acceleration:	654.40761656194569656 cm/sec2
-   Axial tilt:			134.60237510027911867 degrees
+   Equatorial radius:		3463.0195350069608171 Km
+   Density:			5.2429220741986463854 grams/cc
+   Escape Velocity:		5.9282835001484502574 Km/sec
+   Molecular weight retained:	21.24306461330852923 and above
+   Surface acceleration:	606.67810120399925683 cm/sec2
+   Axial tilt:			130.16308419675237928 degrees
    Planetary albedo:		0.07000000000000000666
 
 
-Planet 7
+Planet 8
    Distance from primary star:	1.2702814717675298573 AU
    Eccentricity of orbit:	0.011292305496172449467
-   Length of year:		522.93426169950060756 days
-   Length of day:		20.273066889635962108 hours
-   Mass:			0.3174172187865715076 Earth masses
-   Surface gravity:		0.8661191741121254761 Earth gees
-   Surface pressure:		0.1204092231247647696 Earth atmospheres
-   Surface temperature:		-74.54637936076431316 degrees Celcius
-   Boiling point of water:	49.6912714449018722 degrees Celcius
+   Length of year:		522.9342371302939614 days
+   Length of day:		19.258283959924820214 hours
+   Mass:			0.34868708360437104053 Earth masses
+   Surface gravity:		1.0302638288148448284 Earth gees
+   Surface pressure:		0.15628955169226707571 Earth atmospheres
+   Surface temperature:		-80.555131097972364304 degrees Celcius
+   Boiling point of water:	55.164916223671298212 degrees Celcius
    Hydrosphere percentage:	0%
-   Cloud cover percentage:	0.43315865394576375837%
-   Ice cover percentage:	77.18421127667076356%
-   Equatorial radius:		4221.0418020148675295 Km
-   Density:			6.022110234513133219 grams/cc
-   Escape Velocity:		7.7442849587565776893 Km/sec
-   Molecular weight retained:	6.7195899047126555564 and above
-   Surface acceleration:	849.3727598806674985 cm/sec2
-   Axial tilt:			140.17957927871478319 degrees
-   Planetary albedo:		0.5749246627429376398
+   Cloud cover percentage:	0.49251562604264359586%
+   Ice cover percentage:	85.35713609471300715%
+   Equatorial radius:		4206.9433105107871618 Km
+   Density:			6.6821013561921666865 grams/cc
+   Escape Velocity:		8.130373753353849752 Km/sec
+   Molecular weight retained:	5.6846243182973809314 and above
+   Surface acceleration:	1010.3436776847097662 cm/sec2
+   Axial tilt:			105.99729353840434953 degrees
+   Planetary albedo:		0.6199321383656620122
 
 
-Planet 8
+Planet 9
    Distance from primary star:	1.5232573688759141364 AU
    Eccentricity of orbit:	0.013572953021888612194
-   Length of year:		686.6833039918856707 days
-   Length of day:		14.133614685077906837 hours
-   Mass:			1.2294538870346133282 Earth masses
-   Surface gravity:		1.8382296390979005744 Earth gees
-   Surface pressure:		1.943044351753106437 Earth atmospheres
-   Surface temperature:		-109.83328746791470583 degrees Celcius
-   Boiling point of water:	119.494040893628664435 degrees Celcius
+   Length of year:		686.6831959988640101 days
+   Length of day:		14.046054157651570614 hours
+   Mass:			1.3341239377847115686 Earth masses
+   Surface gravity:		1.802909739249739854 Earth gees
+   Surface pressure:		2.2172214402032715743 Earth atmospheres
+   Surface temperature:		-109.826952271156869756 degrees Celcius
+   Boiling point of water:	123.56515664469952753 degrees Celcius
    Hydrosphere percentage:	0%
-   Cloud cover percentage:	0.34042262284951983338%
+   Cloud cover percentage:	0.36635735437953809935%
    Ice cover percentage:	100%
-   Equatorial radius:		5913.971075567168753 Km
-   Density:			8.481093170660704334 grams/cc
-   Escape Velocity:		12.876339965295740403 Km/sec
-   Molecular weight retained:	1.6446545011789169169 and above
-   Surface acceleration:	1802.6874690259425998 cm/sec2
-   Axial tilt:			105.99729353840434953 degrees
-   Planetary albedo:		0.69938723927887082006
+   Equatorial radius:		6123.691413768453956 Km
+   Density:			8.289597850654847863 grams/cc
+   Escape Velocity:		13.181576365106403828 Km/sec
+   Molecular weight retained:	1.5693681956625243523 and above
+   Surface acceleration:	1768.0504794413460684 cm/sec2
+   Axial tilt:			65.943982781922741765 degrees
+   Planetary albedo:		0.6993405567621167873
 
 
-Planet 9	*gas giant*
+Planet 10	*gas giant*
    Distance from primary star:	2.2760469761771999595 AU
    Eccentricity of orbit:	0.014571506181385933745
-   Length of year:		1254.1707981216138668 days
-   Length of day:		16.214959735347062806 hours
-   Mass:			19.166302541856519605 Earth masses
-   Equatorial radius:		48545.483416236864755 Km
-   Density:			0.2390391451694583223 grams/cc
-   Escape Velocity:		23.85323019359455444 Km/sec
-   Molecular weight retained:	0.49633462457664520557 and above
-   Surface acceleration:	1319.6899065249152835 cm/sec2
-   Axial tilt:			65.943982781922741765 degrees
-   Planetary albedo:		0.09220997387878378333
-
-
-Planet 10
-   Distance from primary star:	3.0651501624522978849 AU
-   Eccentricity of orbit:	0.17813163723997674784
-   Length of year:		1960.0832616080388616 days
-   Length of day:		17.101770279537128661 hours
-   Mass:			0.7235304979306091057 Earth masses
-   Surface gravity:		1.0119997476969686503 Earth gees
-   Surface pressure:		0.54546879246038625555 Earth atmospheres
-   Surface temperature:		-158.07768469477469372 degrees Celcius
-   Boiling point of water:	84.20105100923649388 degrees Celcius
-   Hydrosphere percentage:	0%
-   Cloud cover percentage:	0.0014073656464021931342%
-   Ice cover percentage:	100%
-   Equatorial radius:		5505.0361433614721265 Km
-   Density:			6.1880454699286492146 grams/cc
-   Escape Velocity:		10.238214969730572775 Km/sec
-   Molecular weight retained:	0.7852434074015245946 and above
-   Surface acceleration:	992.4327325752477246 cm/sec2
-   Axial tilt:			115.33677077607131878 degrees
-   Planetary albedo:		0.6999974667418364317
+   Length of year:		1254.145286907297711 days
+   Length of day:		14.50651522233658608 hours
+   Mass:			32.705540882521099498 Earth masses
+   Equatorial radius:		53658.48606644879493 Km
+   Density:			0.30205307995616158836 grams/cc
+   Escape Velocity:		28.823270706243454478 Km/sec
+   Molecular weight retained:	0.54613249979630363093 and above
+   Surface acceleration:	1303.4267704118172677 cm/sec2
+   Axial tilt:			112.91101876386278491 degrees
+   Planetary albedo:		0.097135270458149148194
 
 
 Planet 11
-   Distance from primary star:	4.4095270134381198187 AU
-   Eccentricity of orbit:	0.0082023864671672274155
-   Length of year:		3382.0872024854016644 days
-   Length of day:		20.117283445347503025 hours
-   Mass:			0.8718445036575049511 Earth masses
-   Surface gravity:		0.34250574104153287807 Earth gees
-   Surface pressure:		0.17460273668826325199 Earth atmospheres
-   Surface temperature:		-177.20996155843204653 degrees Celcius
-   Boiling point of water:	57.546893414275359646 degrees Celcius
+   Distance from primary star:	3.0651501624522978849 AU
+   Eccentricity of orbit:	0.17813163723997674784
+   Length of year:		1960.0836590924733526 days
+   Length of day:		19.539516429601885077 hours
+   Mass:			0.58856339012300186014 Earth masses
+   Surface gravity:		0.54985401862815242455 Earth gees
+   Surface pressure:		0.25600662731955974198 Earth atmospheres
+   Surface temperature:		-148.41457306025508936 degrees Celcius
+   Boiling point of water:	66.04640782783309305 degrees Celcius
    Hydrosphere percentage:	0%
-   Cloud cover percentage:	0.00012210912046869608944%
-   Ice cover percentage:	100%
-   Equatorial radius:		7108.9214836176326933 Km
-   Density:			3.462621804749911768 grams/cc
-   Escape Velocity:		9.889937991416141158 Km/sec
-   Molecular weight retained:	0.8132332774801621314 and above
-   Surface acceleration:	335.8833925384948274 cm/sec2
-   Axial tilt:			143.84951966530280743 degrees
-   Planetary albedo:		0.69999978020358311195
+   Cloud cover percentage:	0.0011506949391284858348%
+   Ice cover percentage:	79.23777868333515812%
+   Equatorial radius:		5672.821568058297202 Km
+   Density:			4.6001612166033575926 grams/cc
+   Escape Velocity:		9.096471662710857345 Km/sec
+   Molecular weight retained:	1.3564550886930928505 and above
+   Surface acceleration:	539.2225911779770774 cm/sec2
+   Axial tilt:			81.55638191190649877 degrees
+   Planetary albedo:		0.58580887591853550536
 
 
 Planet 12	*gas giant*
-   Distance from primary star:	6.7269341104082616503 AU
-   Eccentricity of orbit:	0.013999640646665010267
-   Length of year:		6350.519209266069156 days
-   Length of day:		6.529281776273354078 hours
-   Mass:			2328.1180481823469184 Earth masses
-   Equatorial radius:		72025.424843383071575 Km
-   Density:			8.890469367519763875 grams/cc
-   Escape Velocity:		124.79177905455624685 Km/sec
-   Molecular weight retained:	0.50744694167751069506 and above
-   Surface acceleration:	2417.508971851197055 cm/sec2
-   Axial tilt:			61.057211628192284536 degrees
-   Planetary albedo:		0.063549040001534718504
+   Distance from primary star:	4.4095270134381198187 AU
+   Eccentricity of orbit:	0.0082023864671672274155
+   Length of year:		3382.0823583910567438 days
+   Length of day:		27.964375600658941444 hours
+   Mass:			1.8251045386066755698 Earth masses
+   Equatorial radius:		29344.608838151609318 Km
+   Density:			0.103057582114784684675 grams/cc
+   Escape Velocity:		10.089907026993377367 Km/sec
+   Molecular weight retained:	0.56823143011068100806 and above
+   Surface acceleration:	250.20927114693932411 cm/sec2
+   Axial tilt:			16.425025528810063946 degrees
+   Planetary albedo:		0.07519705148470756769
 
 
 Planet 13	*gas giant*
-   Distance from primary star:	18.883882511388664091 AU
-   Eccentricity of orbit:	0.13373694665716038052
-   Length of year:		29947.851145485870356 days
-   Length of day:		9.555951686521395915 hours
-   Mass:			565.39723426850745885 Earth masses
-   Equatorial radius:		58579.48974851720402 Km
-   Density:			4.0132305037180263144 grams/cc
-   Escape Velocity:		72.4133900511814747 Km/sec
-   Molecular weight retained:	0.46822749279312934187 and above
-   Surface acceleration:	2803.1680042273815703 cm/sec2
-   Axial tilt:			111.6635329978806368 degrees
-   Planetary albedo:		0.31499743433230956442
+   Distance from primary star:	6.726454872456255304 AU
+   Eccentricity of orbit:	0.013574670721917439509
+   Length of year:		6365.7777920396335047 days
+   Length of day:		8.510959202277784471 hours
+   Mass:			652.3035700326716637 Earth masses
+   Equatorial radius:		72227.70002488735292 Km
+   Density:			2.470105920725875865 grams/cc
+   Escape Velocity:		79.522608448315551505 Km/sec
+   Molecular weight retained:	0.470854873457733559 and above
+   Surface acceleration:	4846.664451354684267 cm/sec2
+   Axial tilt:			92.02564688856747921 degrees
+   Planetary albedo:		0.079560180485125026134
 
 
-Planet 14	*gas giant*
-   Distance from primary star:	44.540689250152073683 AU
-   Eccentricity of orbit:	0.14502171123628975803
-   Length of year:		105036.01490905448537 days
-   Length of day:		4.7512238497102887544 hours
-   Mass:			22807.018340524934711 Earth masses
-   Equatorial radius:		26385.275075565515122 Km
-   Density:			1771.5801742501970171 grams/cc
-   Escape Velocity:		258.81045371193613858 Km/sec
-   Molecular weight retained:	0.480350060602587003 and above
-   Surface acceleration:	10012.114106273675083 cm/sec2
+Planet 14
+   Distance from primary star:	13.648180577000076059 AU
+   Eccentricity of orbit:	0
+   Length of year:		18416.581102034145806 days
+   Length of day:		17.869518953026788614 hours
+   Mass:			0.7490587732460501819 Earth masses
+   Surface gravity:		0.81576801560142986824 Earth gees
+   Surface pressure:		0.26150205094810797997 Earth atmospheres
+   Surface temperature:		-218.61711988572862946 degrees Celcius
+   Boiling point of water:	66.530934736608628555 degrees Celcius
+   Hydrosphere percentage:	0%
+   Cloud cover percentage:	4.3950872631357646637e-06%
+   Ice cover percentage:	100%
+   Equatorial radius:		5853.124501963980145 Km
+   Density:			5.3300316384483195954 grams/cc
+   Escape Velocity:		10.10275862323748297 Km/sec
+   Molecular weight retained:	0.05916353596327398832 and above
+   Surface acceleration:	799.99514101977619207 cm/sec2
    Axial tilt:			56.343969797334494842 degrees
-   Planetary albedo:		0.30618169742873327347
+   Planetary albedo:		0.69999999208884288197
+
+
+Planet 15	*gas giant*
+   Distance from primary star:	18.997848568563493705 AU
+   Eccentricity of orbit:	0.1276726960001111355
+   Length of year:		30244.772765580602988 days
+   Length of day:		24.989211956402799535 hours
+   Mass:			5.61696320492433811 Earth masses
+   Equatorial radius:		43556.519254267908003 Km
+   Density:			0.09698827999071751781 grams/cc
+   Escape Velocity:		14.137302365960266907 Km/sec
+   Molecular weight retained:	0.0155934301475418022085 and above
+   Surface acceleration:	439.87613835575510088 cm/sec2
+   Axial tilt:			74.082202736207818816 degrees
+   Planetary albedo:		0.31302438463093353139
+
+
+Planet 16	*gas giant*
+   Distance from primary star:	26.744272453248485406 AU
+   Eccentricity of orbit:	0.00343392519934015354
+   Length of year:		50517.515723690898902 days
+   Length of day:		30.738959704740632845 hours
+   Mass:			2.3835069451012859004 Earth masses
+   Equatorial radius:		39347.148449151468977 Km
+   Density:			0.05582822350828211546 grams/cc
+   Escape Velocity:		10.287905228912121384 Km/sec
+   Molecular weight retained:	0.02971653070273890593 and above
+   Surface acceleration:	187.25130251294751736 cm/sec2
+   Axial tilt:			144.42076601789270285 degrees
+   Planetary albedo:		0.30383566353509710157
+
+
+Planet 17
+   Distance from primary star:	44.658659885913400953 AU
+   Eccentricity of orbit:	0.15675788795391934483
+   Length of year:		109007.2291973598898 days
+   Length of day:		18.265706098634100715 hours
+   Mass:			0.90120455136914300455 Earth masses
+   Surface gravity:		0.5107901134760775856 Earth gees
+   Surface pressure:		0.12062466253262446872 Earth atmospheres
+   Surface temperature:		-235.57392314402728317 degrees Celcius
+   Boiling point of water:	49.728166699220651026 degrees Celcius
+   Hydrosphere percentage:	0%
+   Cloud cover percentage:	2.8805497689963078462e-07%
+   Ice cover percentage:	22.891947924602271477%
+   Equatorial radius:		6562.436436346763081 Km
+   Density:			4.54993534202188443 grams/cc
+   Escape Velocity:		10.465380997900370276 Km/sec
+   Molecular weight retained:	0.010298930578808916676 and above
+   Surface acceleration:	500.9139866320176069 cm/sec2
+   Axial tilt:			125.09376369865780987 degrees
+   Planetary albedo:		0.27590571385896470676

--- a/tests/golden/stargen_seed_42.txt
+++ b/tests/golden/stargen_seed_42.txt
@@ -6,15 +6,18 @@ Age: 7.5663580299171949166 billion years	(2.5961288987897613602 billion left on 
 Habitable ecosphere radius: 1.1195233204889958 AU
 
 Planets present at:
-1	0.3556694362521560706 AU	0.08559915019497653133 EM	.
-2	0.42897279519484724856 AU	0.12221739755397304187 EM	o
-3	0.55768756950593494423 AU	0.60798691770870752965 EM	o
-4	0.9614829907153555764 AU	0.72326546463272236377 EM	*
-5	1.4462026994367287258 AU	2.6986804299826640777 EM	o
-6	1.9426215771489064492 AU	0.4369653326019927708 EM	o
-7	3.103655350167082982 AU	58.679757410174293353 EM	o
-8	7.4004806764832269457 AU	3403.8782923746427198 EM	o
-9	42.464789569234503874 AU	34069.78102729019317 EM	o
+1	0.3556694362521560706 AU	0.03519412665792341447 EM	.
+2	0.42887140693515651837 AU	0.065021642960036551685 EM	.
+3	0.55768756950593494423 AU	0.4055982691315685622 EM	o
+4	0.9615657911871555064 AU	0.70275157781690689954 EM	*
+5	1.4462026994367287258 AU	3.1032148593715900868 EM	*
+6	1.9426215771489064492 AU	0.27758054499394701307 EM	o
+7	3.103655350167082982 AU	159.64472935996509803 EM	o
+8	4.803139846391668188 AU	0.09870640215674023548 EM	.
+9	7.4004806764832269457 AU	752.10120006876090143 EM	o
+10	12.278965818860191272 AU	0.5993139392335517376 EM	o
+11	22.58166126909659726 AU	24.378251021053557814 EM	o
+12	40.035451774660471627 AU	2.0991265330649087684 EM	o
 
 
 
@@ -22,44 +25,44 @@ Planet 1
 Planet is tidally locked with one face to star.
    Distance from primary star:	0.3556694362521560706 AU
    Eccentricity of orbit:	0.044167733135100156468
-   Length of year:		77.47598791197246911 days
-   Length of day:		1859.4237098873392586 hours
-   Mass:			0.08559915019497653133 Earth masses
-   Surface gravity:		0.51212340806733745296 Earth gees
+   Length of year:		77.475993779557056115 days
+   Length of day:		1859.4238507093693468 hours
+   Mass:			0.03519412665792341447 Earth masses
+   Surface gravity:		0.3404267003897274555 Earth gees
    Surface pressure:		0 Earth atmospheres
    Surface temperature:		175.09242863588809769 degrees Celcius
    Boiling point of water:	-273.14999999999997726 degrees Celcius
    Hydrosphere percentage:	0%
    Cloud cover percentage:	0%
    Ice cover percentage:	0%
-   Equatorial radius:		2911.8911735194926866 Km
-   Density:			4.9467642260576656283 grams/cc
-   Escape Velocity:		4.8419808446907950565 Km/sec
-   Molecular weight retained:	213.24475531714889419 and above
-   Surface acceleration:	502.22150197235546468 cm/sec2
+   Equatorial radius:		2290.0819068163998704 Km
+   Density:			4.181136290630104019 grams/cc
+   Escape Velocity:		3.5009467005458375206 Km/sec
+   Molecular weight retained:	407.01421856689921264 and above
+   Surface acceleration:	333.84455013769206275 cm/sec2
    Axial tilt:			0 degrees
    Planetary albedo:		0.07000000000000000666
 
 
 Planet 2
 Planet is tidally locked with one face to star.
-   Distance from primary star:	0.42897279519484724856 AU
-   Eccentricity of orbit:	0.010814783589224384575
-   Length of year:		102.62233808580385991 days
-   Length of day:		2462.9361140592926378 hours
-   Mass:			0.12221739755397304187 Earth masses
-   Surface gravity:		0.43698529693520192488 Earth gees
+   Distance from primary star:	0.42887140693515651837 AU
+   Eccentricity of orbit:	0.010529957779484963934
+   Length of year:		102.58596667359151544 days
+   Length of day:		2462.0632001661963706 hours
+   Mass:			0.065021642960036551685 Earth masses
+   Surface gravity:		0.32699448701286721575 Earth gees
    Surface pressure:		0 Earth atmospheres
-   Surface temperature:		135.0014657071091051 degrees Celcius
+   Surface temperature:		135.04970781497866028 degrees Celcius
    Boiling point of water:	-273.14999999999997726 degrees Celcius
    Hydrosphere percentage:	0%
    Cloud cover percentage:	0%
    Ice cover percentage:	0%
-   Equatorial radius:		3418.5853608995337989 Km
-   Density:			4.364866088982583289 grams/cc
-   Escape Velocity:		5.339728946165542584 Km/sec
-   Molecular weight retained:	145.71187715939782331 and above
-   Surface acceleration:	428.53618621895977978 cm/sec2
+   Equatorial radius:		2882.5183398758885676 Km
+   Density:			3.8736366381098576005 grams/cc
+   Escape Velocity:		4.241493837597593665 Km/sec
+   Molecular weight retained:	230.63240548344086708 and above
+   Surface acceleration:	320.67204860647341624 cm/sec2
    Axial tilt:			0 degrees
    Planetary albedo:		0.07000000000000000666
 
@@ -68,131 +71,190 @@ Planet 3
 Planet is tidally locked with one face to star.
    Distance from primary star:	0.55768756950593494423 AU
    Eccentricity of orbit:	0.035200056257495333887
-   Length of year:		152.11898140767440256 days
-   Length of day:		3650.8555537841856613 hours
-   Mass:			0.60798691770870752965 Earth masses
-   Surface gravity:		0.9514355121951241219 Earth gees
+   Length of year:		152.119027665737124 days
+   Length of day:		3650.8566639776909761 hours
+   Mass:			0.4055982691315685622 Earth masses
+   Surface gravity:		0.7899638874045976918 Earth gees
    Surface pressure:		0 Earth atmospheres
    Surface temperature:		84.815154931559050056 degrees Celcius
    Boiling point of water:	-273.14999999999997726 degrees Celcius
    Hydrosphere percentage:	0%
    Cloud cover percentage:	0%
    Ice cover percentage:	0%
-   Equatorial radius:		5236.202914315435144 Km
-   Density:			6.042574429718835174 grams/cc
-   Escape Velocity:		9.623095452829241985 Km/sec
-   Molecular weight retained:	26.010966968546433422 and above
-   Surface acceleration:	933.0395065668313624 cm/sec2
+   Equatorial radius:		4693.5717024349824786 Km
+   Density:			5.5970978664903945597 grams/cc
+   Escape Velocity:		8.301799273515724344 Km/sec
+   Molecular weight retained:	34.898307505905043942 and above
+   Surface acceleration:	774.68993564162976667 cm/sec2
    Axial tilt:			0 degrees
    Planetary albedo:		0.07000000000000000666
 
 
 Planet 4
-   Distance from primary star:	0.9614829907153555764 AU
-   Eccentricity of orbit:	0.027330586151017396968
-   Length of year:		344.35730104966099663 days
-   Length of day:		19.285078354252870514 hours
-   Mass:			0.72326546463272236377 Earth masses
-   Surface gravity:		1.450336186618210357 Earth gees
-   Surface pressure:		0.6751616604151140842 Earth atmospheres
-   Surface temperature:		11.2989385668057781 degrees Celcius
-   Boiling point of water:	89.67706546151975999 degrees Celcius
-   Hydrosphere percentage:	79.783799725236261256%
-   Cloud cover percentage:	46.163839813186639%
-   Ice cover percentage:	2.8942690510717946233%
-   Equatorial radius:		5116.9894799360369726 Km
-   Density:			7.7024933904998623487 grams/cc
-   Escape Velocity:		10.617383700496254023 Km/sec
-   Molecular weight retained:	5.902736948908453873 and above
-   Surface acceleration:	1422.293936449947207 cm/sec2
-   Axial tilt:			162.11315911690562075 degrees
-   Planetary albedo:		0.26959508081866472639
+   Distance from primary star:	0.9615657911871555064 AU
+   Eccentricity of orbit:	0.02782370830972668782
+   Length of year:		344.40179538610635435 days
+   Length of day:		19.503894630163081045 hours
+   Mass:			0.70275157781690689954 Earth masses
+   Surface gravity:		1.431288968348296826 Earth gees
+   Surface pressure:		0.6374057465478117838 Earth atmospheres
+   Surface temperature:		11.1276390417208729255 degrees Celcius
+   Boiling point of water:	88.18328607380306039 degrees Celcius
+   Hydrosphere percentage:	78.73600166173135274%
+   Cloud cover percentage:	45.04321524752556683%
+   Ice cover percentage:	2.9920822800950746538%
+   Equatorial radius:		5077.351779182848753 Km
+   Density:			7.6606786566112598505 grams/cc
+   Escape Velocity:		10.506503222525771707 Km/sec
+   Molecular weight retained:	6.02694545715449487 and above
+   Surface acceleration:	1403.6149961452824548 cm/sec2
+   Axial tilt:			162.12711989020007763 degrees
+   Planetary albedo:		0.26526888829976791656
 
 
 Planet 5
    Distance from primary star:	1.4462026994367287258 AU
    Eccentricity of orbit:	0.04843620426840152801
-   Length of year:		635.2422122676286015 days
-   Length of day:		11.78777651404173511 hours
-   Mass:			2.6986804299826640777 Earth masses
-   Surface gravity:		2.6816726268756052697 Earth gees
-   Surface pressure:		9.44969397708572886 Earth atmospheres
-   Surface temperature:		-105.122578589800047266 degrees Celcius
-   Boiling point of water:	174.54692840455737723 degrees Celcius
-   Hydrosphere percentage:	0%
-   Cloud cover percentage:	0.0740900994206863853%
-   Ice cover percentage:	99.59678461482264405%
-   Equatorial radius:		7288.264181384127543 Km
-   Density:			9.946180099943915804 grams/cc
-   Escape Velocity:		17.184606308799961117 Km/sec
-   Molecular weight retained:	1.0243977423197952997 and above
-   Surface acceleration:	2629.8224866349653444 cm/sec2
+   Length of year:		635.2418261590967404 days
+   Length of day:		11.409088167542811663 hours
+   Mass:			3.1032148593715900868 Earth masses
+   Surface gravity:		2.8594120784365364178 Earth gees
+   Surface pressure:		12.495064931350600777 Earth atmospheres
+   Surface temperature:		4.768107587905320327 degrees Celcius
+   Boiling point of water:	185.91467735562815733 degrees Celcius
+   Hydrosphere percentage:	70.370370370370370364%
+   Cloud cover percentage:	28.057490061796168295%
+   Ice cover percentage:	9.684797543841038901%
+   Equatorial radius:		7568.6566735616223713 Km
+   Density:			10.2125126681984102735 grams/cc
+   Escape Velocity:		18.0830811319828243 Km/sec
+   Molecular weight retained:	0.9251303425212567291 and above
+   Surface acceleration:	2804.125345899965882 cm/sec2
    Axial tilt:			75.14741740661810354 degrees
-   Planetary albedo:		0.6977750108355658192
+   Planetary albedo:		0.22440583856336268842
 
 
 Planet 6
    Distance from primary star:	1.9426215771489064492 AU
    Eccentricity of orbit:	0.07866201705482826778
-   Length of year:		988.9615022942485869 days
-   Length of day:		21.639992476889479215 hours
-   Mass:			0.4369653326019927708 Earth masses
-   Surface gravity:		0.37056145250944173684 Earth gees
-   Surface pressure:		0.11592441720425916259 Earth atmospheres
-   Surface temperature:		-109.53714509418167229 degrees Celcius
-   Boiling point of water:	48.909838909696873088 degrees Celcius
+   Length of year:		988.96173912839402775 days
+   Length of day:		24.04925141997158226 hours
+   Mass:			0.27758054499394701307 Earth masses
+   Surface gravity:		0.30082927485462657456 Earth gees
+   Surface pressure:		0.04677986926523522024 Earth atmospheres
+   Surface temperature:		-104.214631634607419144 degrees Celcius
+   Boiling point of water:	31.29223807135434754 degrees Celcius
    Hydrosphere percentage:	0%
-   Cloud cover percentage:	0.012944579700509219547%
-   Ice cover percentage:	65.00232522931666903%
-   Equatorial radius:		5396.6927448219310937 Km
-   Density:			3.9668071113604306771 grams/cc
-   Escape Velocity:		8.035919092499029357 Km/sec
-   Molecular weight retained:	5.264764560642261517 and above
-   Surface acceleration:	363.39664682517166738 cm/sec2
+   Cloud cover percentage:	0.0110272178321147533725%
+   Ice cover percentage:	52.770201083183883323%
+   Equatorial radius:		4773.8501764642771152 Km
+   Density:			3.6404900441029889265 grams/cc
+   Escape Velocity:		6.8098262317467993126 Km/sec
+   Molecular weight retained:	7.33124959290120948 and above
+   Surface acceleration:	295.0127408253123588 cm/sec2
    Axial tilt:			135.1064706665518429 degrees
-   Planetary albedo:		0.5075250861119571326
+   Planetary albedo:		0.44024658181445184126
 
 
 Planet 7	*gas giant*
    Distance from primary star:	3.103655350167082982 AU
    Eccentricity of orbit:	0.024769427950353692608
-   Length of year:		1996.9597167253597438 days
-   Length of day:		13.179393238023468805 hours
-   Mass:			58.679757410174293353 Earth masses
-   Equatorial radius:		58031.70473991890609 Km
-   Density:			0.4284197685384094509 grams/cc
-   Escape Velocity:		34.997925533248870632 Km/sec
+   Length of year:		1996.6568977103012942 days
+   Length of day:		10.6989065419145865385 hours
+   Mass:			159.64472935996509803 Earth masses
+   Equatorial radius:		65299.395933053207873 Km
+   Density:			0.8180960051639411765 grams/cc
+   Escape Velocity:		49.886910462000621482 Km/sec
    Molecular weight retained:	0.49422987560448737793 and above
-   Surface acceleration:	1872.8484361052898047 cm/sec2
+   Surface acceleration:	2841.9313357831454654 cm/sec2
    Axial tilt:			137.40097724864128281 degrees
    Planetary albedo:		0.08449190559832032668
 
 
-Planet 8	*gas giant*
-   Distance from primary star:	7.4004806764832269457 AU
-   Eccentricity of orbit:	0.032524431387204546173
-   Length of year:		7316.0622248944190034 days
-   Length of day:		6.080655893994097487 hours
-   Mass:			3403.8782923746427198 Earth masses
-   Equatorial radius:		69130.34933396722234 Km
-   Density:			14.700934650152758592 grams/cc
-   Escape Velocity:		142.19545805978080258 Km/sec
-   Molecular weight retained:	0.45012318411566136028 and above
-   Surface acceleration:	5695.3380293690433698 cm/sec2
+Planet 8
+   Distance from primary star:	4.803139846391668188 AU
+   Eccentricity of orbit:	0.0363329853968809317
+   Length of year:		3844.9008212039289005 days
+   Length of day:		29.978039390447176946 hours
+   Mass:			0.09870640215674023548 Earth masses
+   Surface gravity:		0.23896339239079111486 Earth gees
+   Surface pressure:		0.0035432814297826623764 Earth atmospheres
+   Surface temperature:		-181.22508827065981526 degrees Celcius
+   Boiling point of water:	-9.688083485097820358 degrees Celcius
+   Hydrosphere percentage:	0%
+   Cloud cover percentage:	3.8300432040815328733e-05%
+   Ice cover percentage:	100%
+   Equatorial radius:		3564.2960705399786665 Km
+   Density:			3.1102921553814722236 grams/cc
+   Escape Velocity:		4.6996085540479799964 Km/sec
+   Molecular weight retained:	2.0695743719787241394 and above
+   Surface acceleration:	234.34303519891515996 cm/sec2
    Axial tilt:			126.412585009919169465 degrees
-   Planetary albedo:		0.08214002208981067157
+   Planetary albedo:		0.6999999310592222821
 
 
 Planet 9	*gas giant*
-   Distance from primary star:	42.464789569234503874 AU
-   Eccentricity of orbit:	0.28627313362861439572
-   Length of year:		96266.46748886565905 days
-   Length of day:		4.3527676933616359055 hours
-   Mass:			34069.78102729019317 Earth masses
-   Equatorial radius:		37873.567480103583893 Km
-   Density:			894.8245176859768929 grams/cc
-   Escape Velocity:		298.9351768244836852 Km/sec
-   Molecular weight retained:	0.5249161642622320681 and above
-   Surface acceleration:	12651.345463042246845 cm/sec2
-   Axial tilt:			77.9415267693135263 degrees
-   Planetary albedo:		0.30749289620517536158
+   Distance from primary star:	7.4004806764832269457 AU
+   Eccentricity of orbit:	0.032524431387204546173
+   Length of year:		7345.088531209174801 days
+   Length of day:		8.328257103220170711 hours
+   Mass:			752.10120006876090143 Earth masses
+   Equatorial radius:		70851.5948357787046 Km
+   Density:			3.0172032617899600473 grams/cc
+   Escape Velocity:		83.302769657232249155 Km/sec
+   Molecular weight retained:	0.5090263933238804672 and above
+   Surface acceleration:	3528.7518653281885963 cm/sec2
+   Axial tilt:			59.673952359167131476 degrees
+   Planetary albedo:		0.08501583271510309258
+
+
+Planet 10
+   Distance from primary star:	12.278965818860191272 AU
+   Eccentricity of orbit:	0.028901475546966694469
+   Length of year:		15715.914350338152215 days
+   Length of day:		23.042949493135347459 hours
+   Mass:			0.5993139392335517376 Earth masses
+   Surface gravity:		0.266399461443805583 Earth gees
+   Surface pressure:		0.08043205986674068893 Earth atmospheres
+   Surface temperature:		-215.65700677872946282 degrees Celcius
+   Boiling point of water:	41.573999777198253014 degrees Celcius
+   Hydrosphere percentage:	0%
+   Cloud cover percentage:	3.8251558794126944725e-06%
+   Ice cover percentage:	100%
+   Equatorial radius:		6751.2190447153456727 Km
+   Density:			2.7789770500286697199 grams/cc
+   Escape Velocity:		8.414183913359262515 Km/sec
+   Molecular weight retained:	0.1580619273254200741 and above
+   Surface acceleration:	261.24862785678959234 cm/sec2
+   Axial tilt:			44.914932235968912266 degrees
+   Planetary albedo:		0.69999999311471937266
+
+
+Planet 11	*gas giant*
+   Distance from primary star:	22.58166126909659726 AU
+   Eccentricity of orbit:	0.15807503662779803788
+   Length of year:		39193.61160320925956 days
+   Length of day:		18.672142297952891729 hours
+   Mass:			24.378251021053557814 Earth masses
+   Equatorial radius:		40796.54658182911582 Km
+   Density:			0.51228249701974467803 grams/cc
+   Escape Velocity:		23.605923439876032062 Km/sec
+   Molecular weight retained:	0.4822094702719925725 and above
+   Surface acceleration:	438.37740101078818358 cm/sec2
+   Axial tilt:			31.221759670780894425 degrees
+   Planetary albedo:		0.31296698932447732382
+
+
+Planet 12	*gas giant*
+   Distance from primary star:	40.035451774660471627 AU
+   Eccentricity of orbit:	0.13797317233497885525
+   Length of year:		92525.851263507627564 days
+   Length of day:		32.642672175818896914 hours
+   Mass:			2.0991265330649087684 Earth masses
+   Equatorial radius:		37800.77430332134729 Km
+   Density:			0.055451552356424556528 grams/cc
+   Escape Velocity:		9.671286192137215985 Km/sec
+   Molecular weight retained:	0.0150056790754407239454 and above
+   Surface acceleration:	115.83890620832350264 cm/sec2
+   Axial tilt:			66.27619146566983943 degrees
+   Planetary albedo:		0.30613730482936731884

--- a/tests/golden/stargen_seed_7.txt
+++ b/tests/golden/stargen_seed_7.txt
@@ -6,14 +6,16 @@ Age: 7.21457059109049871 billion years	(2.9479163376164575665 billion left on ma
 Habitable ecosphere radius: 1.1195233204889958 AU
 
 Planets present at:
-1	0.31352621900625999072 AU	0.14875832680816320431 EM	o
-2	0.5067601893389549815 AU	0.94135444853442235745 EM	o
-3	0.8210317296924010526 AU	0.09230320562525958991 EM	.
-4	1.0907448503518052304 AU	1.8379161938330471993 EM	o
-5	2.2704109662780684606 AU	21.596641944687767586 EM	o
-6	4.6111487314583936383 AU	99.640806123005275924 EM	o
-7	11.598752025745930624 AU	9808.4128827899048195 EM	o
-8	48.917677941845948454 AU	16308.871522947705702 EM	o
+1	0.31352621900625999072 AU	0.055771788683812297612 EM	.
+2	0.5067601893389549815 AU	0.5707127415151546829 EM	o
+3	0.8210317296924010526 AU	0.08721797189763170687 EM	.
+4	1.0907448503518052304 AU	1.9170235954703192081 EM	o
+5	2.2704109662780684606 AU	17.819444607061895997 EM	o
+6	4.6111487314583936383 AU	461.33340899326759296 EM	o
+7	11.598752025745930624 AU	703.62649732524165946 EM	o
+8	16.084340240521843244 AU	8.380116491038893308 EM	o
+9	34.215336130573957396 AU	0.15381154405988455896 EM	o
+10	48.215196160164372582 AU	0.22609161332517152814 EM	o
 
 
 
@@ -21,21 +23,21 @@ Planet 1
 Planet is tidally locked with one face to star.
    Distance from primary star:	0.31352621900625999072 AU
    Eccentricity of orbit:	0.022919689331519360717
-   Length of year:		64.12214757693903726 days
-   Length of day:		1538.9315418465368942 hours
-   Mass:			0.14875832680816320431 Earth masses
-   Surface gravity:		0.5387685783422058039 Earth gees
+   Length of year:		64.12215653567036947 days
+   Length of day:		1538.9317568560888674 hours
+   Mass:			0.055771788683812297612 Earth masses
+   Surface gravity:		0.34327476470523682654 Earth gees
    Surface pressure:		0 Earth atmospheres
    Surface temperature:		204.26856521860355542 degrees Celcius
    Boiling point of water:	-273.14999999999997726 degrees Celcius
    Hydrosphere percentage:	0%
    Cloud cover percentage:	0%
    Ice cover percentage:	0%
-   Equatorial radius:		3524.6700832275499138 Km
-   Density:			4.847335125840835878 grams/cc
-   Escape Velocity:		5.8017273670414288064 Km/sec
-   Molecular weight retained:	214.79568675882100598 and above
-   Surface acceleration:	528.3514878799592351 cm/sec2
+   Equatorial radius:		2703.7423708258499369 Km
+   Density:			4.0262045050958638697 grams/cc
+   Escape Velocity:		4.0560242560518177924 Km/sec
+   Molecular weight retained:	438.3761921701094487 and above
+   Surface acceleration:	336.63754712966106 cm/sec2
    Axial tilt:			0 degrees
    Planetary albedo:		0.07000000000000000666
 
@@ -44,44 +46,44 @@ Planet 2
 Planet's rotation is in a resonant spin lock with the star.
    Distance from primary star:	0.5067601893389549815 AU
    Eccentricity of orbit:	0.13738414763658656815
-   Length of year:		131.76512522141033532 days
-   Length of day:		2371.7722539853860357 hours
-   Mass:			0.94135444853442235745 Earth masses
-   Surface gravity:		1.6541465092977547788 Earth gees
+   Length of year:		131.76519860050980229 days
+   Length of day:		2371.7735748091764412 hours
+   Mass:			0.5707127415151546829 Earth masses
+   Surface gravity:		1.3143682828764681701 Earth gees
    Surface pressure:		0 Earth atmospheres
-   Surface temperature:		45.58224522305172985 degrees Celcius
+   Surface temperature:		102.37165902612963464 degrees Celcius
    Boiling point of water:	-273.14999999999997726 degrees Celcius
    Hydrosphere percentage:	0%
-   Cloud cover percentage:	99.22926533707410606%
+   Cloud cover percentage:	0%
    Ice cover percentage:	0%
-   Equatorial radius:		5481.445061642724059 Km
-   Density:			8.155398001606886423 grams/cc
-   Escape Velocity:		11.703209170740626287 Km/sec
-   Molecular weight retained:	17.426209230128932099 and above
-   Surface acceleration:	1622.1635865404826299 cm/sec2
+   Equatorial radius:		4788.017305828775196 Km
+   Density:			7.418696637772655516 grams/cc
+   Escape Velocity:		9.750049913249480305 Km/sec
+   Molecular weight retained:	25.017261793913453206 and above
+   Surface acceleration:	1288.9549721270516103 cm/sec2
    Axial tilt:			14.128921366628834022 degrees
-   Planetary albedo:		0.516531694016833495
+   Planetary albedo:		0.07000000000000000666
 
 
 Planet 3
 Planet is tidally locked with one face to star.
    Distance from primary star:	0.8210317296924010526 AU
    Eccentricity of orbit:	0.09812207311223234091
-   Length of year:		271.72976323784255656 days
-   Length of day:		6521.5143177082213573 hours
-   Mass:			0.09230320562525958991 Earth masses
-   Surface gravity:		0.21770394715492302193 Earth gees
+   Length of year:		271.72976531402965727 days
+   Length of day:		6521.5143675367117746 hours
+   Mass:			0.08721797189763170687 Earth masses
+   Surface gravity:		0.21210877619241586665 Earth gees
    Surface pressure:		0 Earth atmospheres
    Surface temperature:		21.873265123607097848 degrees Celcius
    Boiling point of water:	-273.14999999999997726 degrees Celcius
    Hydrosphere percentage:	0%
    Cloud cover percentage:	0%
    Ice cover percentage:	0%
-   Equatorial radius:		3465.4074210758613244 Km
-   Density:			3.1646891567920171612 grams/cc
-   Escape Velocity:		4.6090047096271958434 Km/sec
-   Molecular weight retained:	77.936905990058842245 and above
-   Surface acceleration:	213.49464133668257737 cm/sec2
+   Equatorial radius:		3412.736311939526772 Km
+   Density:			3.1309415615242441968 grams/cc
+   Escape Velocity:		4.514685848099218565 Km/sec
+   Molecular weight retained:	81.22737031693152249 and above
+   Surface acceleration:	208.00765300473549815 cm/sec2
    Axial tilt:			0 degrees
    Planetary albedo:		0.07000000000000000666
 
@@ -89,36 +91,36 @@ Planet is tidally locked with one face to star.
 Planet 4
    Distance from primary star:	1.0907448503518052304 AU
    Eccentricity of orbit:	0.048019808401086067713
-   Length of year:		416.0839046651395247 days
-   Length of day:		13.2190774523866005664 hours
-   Mass:			1.8379161938330471993 Earth masses
-   Surface gravity:		2.3246416007745120142 Earth gees
-   Surface pressure:		4.464718351786033758 Earth atmospheres
-   Surface temperature:		11.939899073214263275 degrees Celcius
-   Boiling point of water:	146.64593702207179149 degrees Celcius
-   Hydrosphere percentage:	93.822079967484631406%
-   Cloud cover percentage:	58.291885422298354867%
-   Ice cover percentage:	4.1024790521199004318%
-   Equatorial radius:		6520.0364299146069724 Km
-   Density:			9.4613436215709207895 grams/cc
-   Escape Velocity:		14.993870357144128066 Km/sec
-   Molecular weight retained:	2.2998410460279830943 and above
-   Surface acceleration:	2279.69465542353674 cm/sec2
+   Length of year:		416.0838552097032845 days
+   Length of day:		13.074917831634465724 hours
+   Mass:			1.9170235954703192081 Earth masses
+   Surface gravity:		2.370090445359390402 Earth gees
+   Surface pressure:		4.8573296165152146245 Earth atmospheres
+   Surface temperature:		12.49800354954195325 degrees Celcius
+   Boiling point of water:	149.6075865504276976 degrees Celcius
+   Hydrosphere percentage:	95.122694711172077434%
+   Cloud cover percentage:	60.93117016020856228%
+   Ice cover percentage:	3.9916862374258740575%
+   Equatorial radius:		6594.721236188012762 Km
+   Density:			9.537077453588382914 grams/cc
+   Escape Velocity:		15.226196087268623523 Km/sec
+   Molecular weight retained:	2.2301931968526450467 and above
+   Surface acceleration:	2324.2647465983665025 cm/sec2
    Axial tilt:			131.19832162136182774 degrees
-   Planetary albedo:		0.3448411563763531135
+   Planetary albedo:		0.35701724343271983703
 
 
 Planet 5	*gas giant*
    Distance from primary star:	2.2704109662780684606 AU
    Eccentricity of orbit:	0.16536867296144835282
-   Length of year:		1249.5107025205476373 days
-   Length of day:		15.813659640256208721 hours
-   Mass:			21.596641944687767586 Earth masses
-   Equatorial radius:		50212.20464688332025 Km
-   Density:			0.24340838552975831659 grams/cc
-   Escape Velocity:		24.885986298758494668 Km/sec
+   Length of year:		1249.5177934578438476 days
+   Length of day:		16.459964304781385723 hours
+   Mass:			17.819444607061895997 Earth masses
+   Equatorial radius:		39592.46654466170955 Km
+   Density:			0.40966953310959813275 grams/cc
+   Escape Velocity:		23.247954748922432773 Km/sec
    Molecular weight retained:	0.5138732321540121599 and above
-   Surface acceleration:	1427.7126407175904975 cm/sec2
+   Surface acceleration:	1317.8089253115710252 cm/sec2
    Axial tilt:			57.700010896413225225 degrees
    Planetary albedo:		0.08794636674003114608
 
@@ -126,14 +128,14 @@ Planet 5	*gas giant*
 Planet 6	*gas giant*
    Distance from primary star:	4.6111487314583936383 AU
    Eccentricity of orbit:	0.06472317548282343475
-   Length of year:		3616.1467386440508056 days
-   Length of day:		12.198780451930869647 hours
-   Mass:			99.640806123005275924 Earth masses
-   Equatorial radius:		62012.363270777602754 Km
-   Density:			0.59618296593324858994 grams/cc
-   Escape Velocity:		41.525852892430233768 Km/sec
+   Length of year:		3614.1837382443345015 days
+   Length of day:		8.864502359593441306 hours
+   Mass:			461.33340899326759296 Earth masses
+   Equatorial radius:		70770.615774478267134 Km
+   Density:			1.8570908989318242634 grams/cc
+   Escape Velocity:		71.45686972884759307 Km/sec
    Molecular weight retained:	0.46860179990157329035 and above
-   Surface acceleration:	854.6540350691374161 cm/sec2
+   Surface acceleration:	1618.5062406807054026 cm/sec2
    Axial tilt:			65.79962314833117887 degrees
    Planetary albedo:		0.07600438475314364071
 
@@ -141,28 +143,72 @@ Planet 6	*gas giant*
 Planet 7	*gas giant*
    Distance from primary star:	11.598752025745930624 AU
    Eccentricity of orbit:	0.084224604222405489106
-   Length of year:		14220.224288001453366 days
-   Length of day:		5.0635824871408484297 hours
-   Mass:			9808.4128827899048195 Earth masses
-   Equatorial radius:		66955.85227312089705 Km
-   Density:			46.624081565607278562 grams/cc
-   Escape Velocity:		203.01969570685464889 Km/sec
+   Length of year:		14413.040235385907002 days
+   Length of day:		8.766872108812357276 hours
+   Mass:			703.62649732524165946 Earth masses
+   Equatorial radius:		70897.76990023865215 Km
+   Density:			2.8172256918665285258 grams/cc
+   Escape Velocity:		79.851052201864765955 Km/sec
    Molecular weight retained:	0.5403257646087370956 and above
-   Surface acceleration:	10724.876954757237319 cm/sec2
+   Surface acceleration:	3577.8221995302317815 cm/sec2
    Axial tilt:			152.14227291220413463 degrees
    Planetary albedo:		0.06970031433125197809
 
 
 Planet 8	*gas giant*
-   Distance from primary star:	48.917677941845948454 AU
-   Eccentricity of orbit:	0.058739490432363934962
-   Length of year:		122013.134033580326474 days
-   Length of day:		5.135000919694144587 hours
-   Mass:			16308.871522947705702 Earth masses
-   Equatorial radius:		33672.14030278026079 Km
-   Density:			609.521350399160333 grams/cc
-   Escape Velocity:		228.93023143309488893 Km/sec
-   Molecular weight retained:	0.5417322311753683836 and above
-   Surface acceleration:	9011.54626251851938 cm/sec2
+   Distance from primary star:	16.084340240521843244 AU
+   Eccentricity of orbit:	0.056649266129099651312
+   Length of year:		23561.165375476410265 days
+   Length of day:		22.674089889204775703 hours
+   Mass:			8.380116491038893308 Earth masses
+   Equatorial radius:		37586.546918475998417 Km
+   Density:			0.22518006878903896537 grams/cc
+   Escape Velocity:		16.402687629575310275 Km/sec
+   Molecular weight retained:	0.016160212390331134522 and above
+   Surface acceleration:	462.1901017144622824 cm/sec2
    Axial tilt:			145.41254209601916614 degrees
-   Planetary albedo:		0.31154912256704087495
+   Planetary albedo:		0.311497064866191687
+
+
+Planet 9
+   Distance from primary star:	34.215336130573957396 AU
+   Eccentricity of orbit:	0.11288505050073853464
+   Length of year:		73101.867977330240585 days
+   Length of day:		24.78802820889064635 hours
+   Mass:			0.15381154405988455896 Earth masses
+   Surface gravity:		0.34609769173271115225 Earth gees
+   Surface pressure:		3.5418755248773286723e-05 Earth atmospheres
+   Surface temperature:		-228.4708753713865832 degrees Celcius
+   Boiling point of water:	-60.72384207056404648 degrees Celcius
+   Hydrosphere percentage:	0%
+   Cloud cover percentage:	1.4955356426250678019e-09%
+   Ice cover percentage:	0.07850852645417862023%
+   Equatorial radius:		3679.2000613437571268 Km
+   Density:			4.406623018970594791 grams/cc
+   Escape Velocity:		5.774224624712181976 Km/sec
+   Molecular weight retained:	0.028817388740430401826 and above
+   Surface acceleration:	339.40589286305916952 cm/sec2
+   Axial tilt:			65.29397916144770875 degrees
+   Planetary albedo:		0.1504317968969187357
+
+
+Planet 10
+   Distance from primary star:	48.215196160164372582 AU
+   Eccentricity of orbit:	0.06741210509082971869
+   Length of year:		122284.98038136711079 days
+   Length of day:		28.524550989367331327 hours
+   Mass:			0.22609161332517152814 Earth masses
+   Surface gravity:		0.20646719834364778789 Earth gees
+   Surface pressure:		4.6034820014888717547e-05 Earth atmospheres
+   Surface temperature:		-244.13625141866297123 degrees Celcius
+   Boiling point of water:	-58.355427736617315304 degrees Celcius
+   Hydrosphere percentage:	0%
+   Cloud cover percentage:	7.7024114940837204276e-10%
+   Ice cover percentage:	100%
+   Equatorial radius:		5133.079605591461483 Km
+   Density:			2.3852155534376272455 grams/cc
+   Escape Velocity:		5.9269209802009444684 Km/sec
+   Molecular weight retained:	0.027547832978247132874 and above
+   Surface acceleration:	202.4751550636733504 cm/sec2
+   Axial tilt:			105.211996063647291066 degrees
+   Planetary albedo:		0.6999999999986135215


### PR DESCRIPTION
## Why revert

PR #44 (Lynden-Bell–Pringle disk profile) is **physically broken** and must come off master.

My validation in #44 checked *architecture* metrics but not *masses*. Re-measuring with the harness (new mass metric, included here) shows the LBP profile inflates solid masses ~30× and routinely produces brown-dwarf-mass "planets":

| (60 solar-mass systems) | Dole (good) | LBP (#44) |
|---|---|---|
| median system total mass | 899 M⊕ | 27,040 M⊕ |
| median *largest* planet | 594 M⊕ (~1.9 M_Jup) | 20,126 M⊕ (~63 M_Jup) |

The committed golden for seed 12345 on master even contains a 22,807 M⊕ (~72 M_Jup) "planet". The peas-in-a-pod "improvement" reported in #44 was **spurious** — sizes correlated because everything bloated into uniform giants, not because of realistic architecture.

Root cause: I normalized the LBP volume-density analog by anchoring at a single radius (a=1 AU) instead of preserving the total disk solid mass. Combined with the nonlinear gas-capture (K-law), the over-massive outer disk runs away into giants — exactly the Isaacman & Sagan (1977) "high nebula mass → pathological systems" warning.

## What this PR does
1. Reverts the #44 merge (restores the validated Dole profile + pre-#44 goldens).
2. Adds a **mean total-planet-mass** metric to `scripts/validate_population.py` — the diagnostic that catches this class of regression. Post-revert: mean total 939 M⊕, largest ~1.9 M_Jup (sane).

## Follow-up
The disk-profile modernization is re-opened on the board with a **mass-preserving normalization** requirement (match ∫a²ρ to the Dole total) and a DoD that validates masses *and* architecture. The LBP radial *shape* is still worth adopting — but only with correct normalization.

Verified: `scripts/verify.sh` → 100% tests passed, 0 failed out of 13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)