### PR TITLE
chore: remove unused moon backup/restore mechanism

### DIFF
--- a/planets.cpp
+++ b/planets.cpp
@@ -347,7 +347,6 @@ static void init_solar_system_planets() {
   pluto->setGasGiant(false);
   pluto->setDustMass(EM(0.002));
   pluto->addMoon(charon);
-  pluto->backupMoons();
   pluto->first_moon = charon;  // Legacy compatibility
   pluto->next_planet = eris;
   pluto->first_moon_backup = charon;  // Legacy compatibility
@@ -361,7 +360,6 @@ static void init_solar_system_planets() {
   neptune->setDustMass(EM(1.2));
   neptune->setGasMass(EM(17.14 - 1.2));
   neptune->addMoon(triton);
-  neptune->backupMoons();
   neptune->first_moon = triton;  // Legacy compatibility
   neptune->next_planet = pluto;
   neptune->first_moon_backup = triton;  // Legacy compatibility
@@ -385,7 +383,6 @@ static void init_solar_system_planets() {
   saturn->setDustMass(EM(9));
   saturn->setGasMass(EM(95.18 - 9));
   saturn->addMoon(tethys);
-  saturn->backupMoons();
   saturn->first_moon = tethys;  // Legacy compatibility
   saturn->next_planet = uranus;
   saturn->first_moon_backup = tethys;  // Legacy compatibility
@@ -399,7 +396,6 @@ static void init_solar_system_planets() {
   jupiter->setDustMass(EM(10));
   jupiter->setGasMass(EM(317.9 - 10));
   jupiter->addMoon(io);
-  jupiter->backupMoons();
   jupiter->first_moon = io;  // Legacy compatibility
   jupiter->next_planet = saturn;
   jupiter->first_moon_backup = io;  // Legacy compatibility
@@ -429,7 +425,6 @@ static void init_solar_system_planets() {
   earth->setGasGiant(false);
   earth->setDustMass(EM(1.0));
   earth->addMoon(luna);
-  earth->backupMoons();
   earth->first_moon = luna;  // Legacy compatibility
   earth->next_planet = mars;
   earth->first_moon_backup = luna;  // Legacy compatibility
@@ -1085,7 +1080,6 @@ static void init_exoplanets() {
   bajorVIII->setDustMass(EM(1.3080413057739237));
   bajorVIII->addMoon(bajorVIII1);
   bajorVIII->addMoon(bajorVIII2);
-  bajorVIII->backupMoons();
   bajorVIII->first_moon = bajorVIII1;  // Legacy compatibility
   bajorVIII->next_planet = bajorIX;
   bajorVIII->first_moon_backup = bajorVIII1;  // Legacy compatibility
@@ -1128,7 +1122,6 @@ static void init_exoplanets() {
   bajorVII->addMoon(bajorVII1);
   bajorVII->addMoon(bajorVII2);
   bajorVII->addMoon(bajorVII3);
-  bajorVII->backupMoons();
   bajorVII->first_moon = jeraddo;  // Legacy compatibility
   bajorVII->next_planet = bajorVIII;
   bajorVII->first_moon_backup = jeraddo;  // Legacy compatibility

--- a/structs.cpp
+++ b/structs.cpp
@@ -1057,7 +1057,6 @@ planet::~planet() {
     }
   }
   moons.clear();
-  moons_backup.clear();
   first_moon = nullptr;  // chain is now a dangling view of freed moons; drop it
 }
 

--- a/structs.h
+++ b/structs.h
@@ -321,22 +321,6 @@ class planet {
     moons.push_back(moon);
   }
 
-  void backupMoons() {
-    moons_backup.clear();
-    moons_backup = moons;  // Copy the vector
-  }
-
-  void restoreMoons() {
-    // Delete generated (deletable) moons
-    for (planet* moon : moons) {
-      if (moon->getDeletable()) {
-        delete moon;
-      }
-    }
-    moons.clear();
-    moons = moons_backup;  // Restore from backup
-  }
-
   void deleteMoon(size_t index) {
     if (index < moons.size()) {
       delete moons[index];
@@ -351,7 +335,6 @@ class planet {
   }
 
   std::vector<planet*> moons;  // Vector of moons (PRIMARY - use this)
-  std::vector<planet*> moons_backup;  // Backup for predefined moons
 
   // DEPRECATED: Legacy linked list pointers - to be removed
   planet *first_moon;  // DEPRECATED: Use moons vector instead


### PR DESCRIPTION
Removes dead code: `planet::backupMoons()`/`restoreMoons()`, the `moons_backup` vector member and its destructor cleanup, and the `backupMoons()` call sites in `planets.cpp`. `restoreMoons()` had no callers and `backupMoons()` only fed it, so the entire backup path was unreachable. The `moons` vector and the legacy `first_moon_backup` pointer are untouched.

Verified: `scripts/verify.sh` → 100% tests passed, 0 failed out of 13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined moon data management by removing backup and restore mechanisms from planet initialization and destruction processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->