### PR TITLE
M-dwarf habitability caveat flags

### DIFF
--- a/PlanetRow.h
+++ b/PlanetRow.h
@@ -116,6 +116,9 @@ struct PlanetRow {
   [[=planetrow::fixed_string("Atmosphere")]]                     std::string atmosphere;   // CSV-style ({:.2f}); JSON overrides with atmosphere_json
   [[=planetrow::fixed_string("Type")]]                           std::string type;
   [[=planetrow::fixed_string("Minor Moons")]]                    int         minor_moons;
+  [[=planetrow::fixed_string("Tidally Locked")]]                 bool        tidally_locked;
+  [[=planetrow::fixed_string("PMS Desiccation Risk")]]           bool        pms_desiccation_risk;
+  [[=planetrow::fixed_string("High XUV Escape Risk")]]           bool        high_xuv_escape_risk;
 
   // --- helper fields: no annotation, skipped by the reflective emitters ---
   std::string atmosphere_json;  // JSON-style atmosphere (toString formatting)

--- a/display.cpp
+++ b/display.cpp
@@ -122,6 +122,16 @@ static void text_print_planet_details(planet* the_planet, int counter) {
     std::cout << "Planet's rotation is in a resonant spin lock with the star.\n";
   }
 
+  // Habitability caveats (notably for M-dwarf hosts); see set_habitability_flags.
+  if (the_planet->getPmsDesiccationRisk()) {
+    std::cout << "Likely desiccated during the host M-dwarf's pre-main-sequence "
+                 "phase (possible abiotic-O2 \"mirage Earth\").\n";
+  }
+  if (the_planet->getHighXuvEscapeRisk()) {
+    std::cout << "High atmospheric-escape risk from M-dwarf XUV/flare "
+                 "irradiation.\n";
+  }
+
   // Orbital properties
   std::cout << std::format("   Distance from primary star:\t{} AU\n", the_planet->getA())
             << std::format("   Eccentricity of orbit:\t{}\n", the_planet->getE())
@@ -441,6 +451,9 @@ auto to_row(planet* the_planet, bool is_moon, const std::string& id, bool do_gas
   r.atmosphere                   = generate_atmosphere_string(the_planet, do_gases);  // CSV-style
   r.type                         = type_string(the_planet);
   r.minor_moons                  = the_planet->getMinorMoons();
+  r.tidally_locked               = the_planet->getTidallyLocked();
+  r.pms_desiccation_risk         = the_planet->getPmsDesiccationRisk();
+  r.high_xuv_escape_risk         = the_planet->getHighXuvEscapeRisk();
   r.atmosphere_json              = atmosphere_json;
   r.is_moon                      = is_moon;
   return r;

--- a/enviro.cpp
+++ b/enviro.cpp
@@ -2851,6 +2851,43 @@ auto calcSph(planet *the_planet) -> long double {
   return ht * hrh;
 }
 
+/**
+ * @brief Set derived habitability caveat flags on the planet.
+ *
+ * "In the habitable zone" is necessary but not sufficient, especially around M
+ * dwarfs. These flags surface well-known caveats computed from already-derived
+ * quantities (host effective temperature/mass, orbital distance, the HZ distance
+ * metric, surface gravity, rotation state):
+ *  - tidally_locked: synchronous or spin-orbit-resonant rotation.
+ *  - pms_desiccation_risk: an M-dwarf HZ terrestrial likely spent the host's
+ *    super-luminous pre-main-sequence phase in a runaway greenhouse, losing its
+ *    water and possibly building abiotic O2 (a "mirage Earth"); Luger & Barnes
+ *    2015, Astrobiology 15, 119.
+ *  - high_xuv_escape_risk: a close-in M-dwarf terrestrial at elevated atmospheric
+ *    escape risk from quiescent XUV and flares.
+ * See research/modern/06-habitable-zone-climate.md.
+ */
+void set_habitability_flags(planet *the_planet) {
+  sun host = the_planet->getTheSun();
+  long double host_mass = host.getMass();
+  // M dwarf: M_star < ~0.6 Msun. Keyed on mass, which is reliably populated; the
+  // host effective temperature is not always derived on the -m generation path
+  // (it can default to a placeholder), so it is not used here.
+  bool m_dwarf = host_mass > 0.0 && host_mass < 0.6;
+
+  long double year_hours = the_planet->getOrbPeriod() * 24.0;
+  bool locked = the_planet->getResonantPeriod() ||
+                (year_hours > 0.0 && the_planet->getDay() >= year_hours * 0.9999);
+  the_planet->setTidallyLocked(locked);
+
+  bool rocky = !is_gas_planet(the_planet);
+  bool in_hz = std::fabs((double)the_planet->getHzd()) <= 1.0;
+
+  the_planet->setPmsDesiccationRisk(m_dwarf && rocky && in_hz);
+  the_planet->setHighXuvEscapeRisk(m_dwarf && rocky && the_planet->getA() < 0.4 &&
+                                   the_planet->getSurfGrav() < 1.0);
+}
+
 auto is_potentialy_habitable_optimistic_size(planet *the_planet) -> bool {
   /*if ((the_planet->getMass() * SUN_MASS_IN_EARTH_MASSES) > 10.0 ||
    (the_planet->getMass() * SUN_MASS_IN_EARTH_MASSES) < 0.1) // The Plantary

--- a/enviro.h
+++ b/enviro.h
@@ -120,6 +120,7 @@ auto is_potentialy_habitable_earth_like(planet *) -> bool;
 auto is_habitable_earth_like(planet *) -> bool;
 auto is_potentialy_habitable(planet *) -> bool;
 auto is_habitable(planet *) -> bool;
+void set_habitability_flags(planet *);
 auto convert_km_to_eu(long double) -> long double;
 void makeHabitable(StarGenerator*, sun &, planet *, const std::string&, bool, bool);
 

--- a/stargen.cpp
+++ b/stargen.cpp
@@ -2369,6 +2369,7 @@ void generate_planet(StarGenerator* gen, planet *the_planet, int planet_no, sun 
   the_planet->setHza(calcHza(the_planet));
   the_planet->setEsi(calcEsi(the_planet));
   the_planet->setSph(calcSph(the_planet));
+  set_habitability_flags(the_planet);
 
   // Generate moons for this planet (if not a moon itself)
   generate_moons(gen, the_planet, planet_no, the_sun, random_tilt, planet_id,

--- a/structs.cpp
+++ b/structs.cpp
@@ -1271,6 +1271,12 @@ auto planet::getRadius() -> long double { return radius; }
 
 auto planet::getResonantPeriod() -> bool { return resonantPeriod; }
 
+auto planet::getTidallyLocked() -> bool { return tidallyLocked; }
+
+auto planet::getPmsDesiccationRisk() -> bool { return pmsDesiccationRisk; }
+
+auto planet::getHighXuvEscapeRisk() -> bool { return highXuvEscapeRisk; }
+
 auto planet::getRmf() -> long double { return rmf; }
 
 auto planet::getRmsVelocity() -> long double { return rmsVelocity; }
@@ -1424,6 +1430,12 @@ void planet::setRadius(long double r) {
 }
 
 void planet::setResonantPeriod(bool r) { resonantPeriod = r; }
+
+void planet::setTidallyLocked(bool b) { tidallyLocked = b; }
+
+void planet::setPmsDesiccationRisk(bool b) { pmsDesiccationRisk = b; }
+
+void planet::setHighXuvEscapeRisk(bool b) { highXuvEscapeRisk = b; }
 
 void planet::setRmf(long double r) { rmf = r; }
 

--- a/structs.h
+++ b/structs.h
@@ -167,6 +167,13 @@ class planet {
   long double oblateness{};
   bool deleteable{true};
   long double knownRadius{};
+  // Derived habitability caveat flags (set by set_habitability_flags()).
+  bool tidallyLocked{false};       /* synchronous or spin-orbit resonant rotation */
+  bool pmsDesiccationRisk{false};  /* M-dwarf HZ world likely desiccated in the
+                                      pre-main-sequence phase -> abiotic-O2 "mirage
+                                      Earth" (Luger & Barnes 2015) */
+  bool highXuvEscapeRisk{false};   /* close-in M-dwarf world at high atmospheric-
+                                      escape risk from XUV/flares */
   void estimateMass();
  public:
   planet();
@@ -212,6 +219,12 @@ class planet {
   auto getDay() -> long double;
   void setResonantPeriod(bool);
   auto getResonantPeriod() -> bool;
+  void setTidallyLocked(bool);
+  auto getTidallyLocked() -> bool;
+  void setPmsDesiccationRisk(bool);
+  auto getPmsDesiccationRisk() -> bool;
+  void setHighXuvEscapeRisk(bool);
+  auto getHighXuvEscapeRisk() -> bool;
   void setEscVelocity(long double);
   auto getEscVelocity() -> long double;
   void setSurfAccel(long double);


### PR DESCRIPTION
## Summary

Adds three derived per-planet habitability-caveat flags — "in the HZ" is necessary but not sufficient, especially around M dwarfs — surfaced in JSON/CSV output and as text caveat lines. Computed by `set_habitability_flags()` from already-derived quantities (no accretion-core change):

- **tidally_locked** — synchronous or spin-orbit-resonant rotation.
- **pms_desiccation_risk** — an M-dwarf (M\* < 0.6 M☉) HZ terrestrial likely desiccated during the host's super-luminous pre-main-sequence phase → abiotic-O₂ "mirage Earth" (Luger & Barnes 2015, Astrobiology 15, 119).
- **high_xuv_escape_risk** — close-in (a < 0.4 AU) low-gravity M-dwarf terrestrial at elevated atmospheric-escape risk from XUV/flares.

The M-dwarf test is keyed on stellar **mass**, not effective temperature, because Teff is not reliably derived on the `-m` generation path (it can default to a ~273 K placeholder — a pre-existing quirk).

## Validation
- Flags fire for low-mass hosts (`-m0.3`), not for solar (`-m1.0`).
- **Purely additive**: text caveat lines only print when a flag is true, so the solar-mass goldens are **unchanged** (golden regression passes without regeneration); the new JSON/CSV fields are deterministic.
- `scripts/verify.sh --determinism` → 100% tests passed, 0 failed out of 13; 10× -T8 + -T1/-T2/-T4 byte-identical.

Ref: `research/modern/06-habitable-zone-climate.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three new habitability indicators for planets: Tidal Locking status, PMS Desiccation Risk, and High XUV Escape Risk.
  * These new fields are now included in exported planet data (JSON and CSV formats).
  * Enhanced planet detail displays with additional habitability caveats and warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->