### PR TITLE
Habitability: CO2-collapse / deglaciation-risk flag

### DIFF
--- a/PlanetRow.h
+++ b/PlanetRow.h
@@ -119,6 +119,7 @@ struct PlanetRow {
   [[=planetrow::fixed_string("Tidally Locked")]]                 bool        tidally_locked;
   [[=planetrow::fixed_string("PMS Desiccation Risk")]]           bool        pms_desiccation_risk;
   [[=planetrow::fixed_string("High XUV Escape Risk")]]           bool        high_xuv_escape_risk;
+  [[=planetrow::fixed_string("CO2 Collapse Risk")]]              bool        co2_collapse_risk;
 
   // --- helper fields: no annotation, skipped by the reflective emitters ---
   std::string atmosphere_json;  // JSON-style atmosphere (toString formatting)

--- a/display.cpp
+++ b/display.cpp
@@ -131,6 +131,10 @@ static void text_print_planet_details(planet* the_planet, int counter) {
     std::cout << "High atmospheric-escape risk from M-dwarf XUV/flare "
                  "irradiation.\n";
   }
+  if (the_planet->getCo2CollapseRisk()) {
+    std::cout << "Cold for the habitable zone: outgassed CO2 may freeze out, "
+                 "risking irreversible glaciation.\n";
+  }
 
   // Orbital properties
   std::cout << std::format("   Distance from primary star:\t{} AU\n", the_planet->getA())
@@ -454,6 +458,7 @@ auto to_row(planet* the_planet, bool is_moon, const std::string& id, bool do_gas
   r.tidally_locked               = the_planet->getTidallyLocked();
   r.pms_desiccation_risk         = the_planet->getPmsDesiccationRisk();
   r.high_xuv_escape_risk         = the_planet->getHighXuvEscapeRisk();
+  r.co2_collapse_risk            = the_planet->getCo2CollapseRisk();
   r.atmosphere_json              = atmosphere_json;
   r.is_moon                      = is_moon;
   return r;

--- a/enviro.cpp
+++ b/enviro.cpp
@@ -2886,6 +2886,13 @@ void set_habitability_flags(planet *the_planet) {
   the_planet->setPmsDesiccationRisk(m_dwarf && rocky && in_hz);
   the_planet->setHighXuvEscapeRisk(m_dwarf && rocky && the_planet->getA() < 0.4 &&
                                    the_planet->getSurfGrav() < 1.0);
+
+  // On a cold HZ world, outgassed CO2 can condense out before the carbonate-
+  // silicate thermostat warms the planet, risking irreversible glaciation
+  // (Turbet et al. 2017, EPSL 476, 11). Flag rocky HZ planets currently below
+  // the water freezing point.
+  the_planet->setCo2CollapseRisk(
+      rocky && in_hz && the_planet->getSurfTemp() < FREEZING_POINT_OF_WATER);
 }
 
 auto is_potentialy_habitable_optimistic_size(planet *the_planet) -> bool {

--- a/structs.cpp
+++ b/structs.cpp
@@ -1277,6 +1277,8 @@ auto planet::getPmsDesiccationRisk() -> bool { return pmsDesiccationRisk; }
 
 auto planet::getHighXuvEscapeRisk() -> bool { return highXuvEscapeRisk; }
 
+auto planet::getCo2CollapseRisk() -> bool { return co2CollapseRisk; }
+
 auto planet::getRmf() -> long double { return rmf; }
 
 auto planet::getRmsVelocity() -> long double { return rmsVelocity; }
@@ -1436,6 +1438,8 @@ void planet::setTidallyLocked(bool b) { tidallyLocked = b; }
 void planet::setPmsDesiccationRisk(bool b) { pmsDesiccationRisk = b; }
 
 void planet::setHighXuvEscapeRisk(bool b) { highXuvEscapeRisk = b; }
+
+void planet::setCo2CollapseRisk(bool b) { co2CollapseRisk = b; }
 
 void planet::setRmf(long double r) { rmf = r; }
 

--- a/structs.h
+++ b/structs.h
@@ -174,6 +174,9 @@ class planet {
                                       Earth" (Luger & Barnes 2015) */
   bool highXuvEscapeRisk{false};   /* close-in M-dwarf world at high atmospheric-
                                       escape risk from XUV/flares */
+  bool co2CollapseRisk{false};     /* HZ world cold enough that outgassed CO2 may
+                                      condense out, risking irreversible
+                                      glaciation (Turbet et al. 2017) */
   void estimateMass();
  public:
   planet();
@@ -225,6 +228,8 @@ class planet {
   auto getPmsDesiccationRisk() -> bool;
   void setHighXuvEscapeRisk(bool);
   auto getHighXuvEscapeRisk() -> bool;
+  void setCo2CollapseRisk(bool);
+  auto getCo2CollapseRisk() -> bool;
   void setEscVelocity(long double);
   auto getEscVelocity() -> long double;
   void setSurfAccel(long double);

--- a/tests/golden/stargen_seed_12345.txt
+++ b/tests/golden/stargen_seed_12345.txt
@@ -187,6 +187,7 @@ Planet 7
 
 
 Planet 8
+Cold for the habitable zone: outgassed CO2 may freeze out, risking irreversible glaciation.
    Distance from primary star:	1.2702814717675298573 AU
    Eccentricity of orbit:	0.011292305496172449467
    Length of year:		522.9342371302939614 days


### PR DESCRIPTION
## Summary

Extends `set_habitability_flags()` with a fourth habitability caveat, **co2_collapse_risk**: a rocky planet in the conservative habitable zone whose surface temperature is below the water freezing point is flagged as at risk of *irreversible glaciation* — on a cold HZ world, outgassed CO₂ can condense out before the carbonate-silicate thermostat warms the planet (Turbet et al. 2017, EPSL 476, 11). Surfaced in JSON/CSV and a text caveat line.

Completes the habitability-caveat-flags set (alongside tidally_locked / pms_desiccation_risk / high_xuv_escape_risk from #47).

## Validation
- Additive; one golden line added (seed 12345 has a single cold outer-HZ planet that trips the flag).
- `scripts/verify.sh --determinism` → 100% tests passed, 0 failed out of 13; 10× -T8 + -T1/-T2/-T4 byte-identical.

Ref: `research/modern/06-habitable-zone-climate.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CO2 Collapse Risk detection for habitable-zone planets with freezing surface temperatures, identifying potential atmospheric freeze-out conditions.
  * Risk indicator now displays in planet detail views and is exported through CSV/JSON data formats.
  * New habitability caveat warns when planets face CO2 atmospheric condensation risks that could trigger irreversible glaciation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->