### PR TITLE
fix(stellar): physical effective temperature + spectral type for -m stars (fixes HZ)

### DIFF
--- a/enviro.cpp
+++ b/enviro.cpp
@@ -93,6 +93,33 @@ auto luminosity_to_mass(long double luminosity) -> long double {
 }
 
 /**
+ * @brief Main-sequence effective temperature from stellar mass + luminosity.
+ *
+ * Used when a star is specified by mass (or luminosity) with no spectral type, so
+ * its effective temperature would otherwise default to a placeholder. Above 1.5
+ * Msun uses the Eker et al. 2018 mass-Teff relation
+ * (log Teff = -0.170 (log M)^2 + 0.888 log M + 3.671); at or below 1.5 Msun
+ * derives Teff from luminosity and the Eker mass-radius relation
+ * (R = 0.438 M^2 + 0.479 M + 0.075) via Stefan-Boltzmann, anchored so the Sun
+ * (1 Msun) -> ~5778 K. See research/modern/07-stellar-relations-binaries.md.
+ *
+ * @param mass stellar mass in solar masses
+ * @param luminosity luminosity in solar luminosities
+ * @return effective temperature in Kelvin
+ */
+auto mass_to_eff_temp(long double mass, long double luminosity) -> long double {
+    if (mass > 1.5L) {
+        const long double lm = std::log10(mass);
+        return std::pow(10.0L, -0.170L * lm * lm + 0.888L * lm + 3.671L);
+    }
+    long double radius = 0.438L * mass * mass + 0.479L * mass + 0.075L;  // Rsun
+    if (radius <= 0.0L) {
+        radius = 1.0L;
+    }
+    return 5778.0L * std::pow(luminosity / (radius * radius), 0.25L);
+}
+
+/**
  * @brief Get the Lum Index
  * 
  * @param spec_type 
@@ -212,10 +239,15 @@ long double spec_type_to_eff_temp(const std::string& spec_type) {
  * @return std::string 
  */
 std::string eff_temp_to_spec_type(long double eff_temp, long double luminosity) {
+    // Lower temperature bound of each spectral class, on the standard
+    // Morgan-Keenan / Pecaut & Mamajek (2013) scale. The previous boundaries
+    // were miscalibrated (e.g. G set at 6000 K, so a 5778 K Sun fell into K, and
+    // O was never reachable), which produced wrong spectral types for stars whose
+    // type is derived from effective temperature.
     static const std::vector<std::pair<long double, std::string>> temp_classes = {
-        {52000, "O"}, {30000, "B"}, {10000, "A"}, {7500, "F"}, 
-        {6000, "G"}, {5000, "K"}, {3500, "M"}, {2000, "L"}, 
-        {1300, "T"}, {700, "Y"}
+        {30000, "O"}, {10000, "B"}, {7300, "A"}, {6000, "F"},
+        {5300, "G"}, {3900, "K"}, {2300, "M"}, {1300, "L"},
+        {600, "T"}, {0, "Y"}
     };
 
     auto get_spec_class = [&]() {

--- a/enviro.h
+++ b/enviro.h
@@ -15,6 +15,7 @@ extern thread_local std::map<std::map<long double, long double>, std::vector<lon
 
 auto mass_to_luminosity(long double) -> long double;
 auto luminosity_to_mass(long double) -> long double;
+auto mass_to_eff_temp(long double mass, long double luminosity) -> long double;
 auto getStarType(std::string) -> std::string;
 auto getSubType(std::string) -> int;
 auto spec_type_to_eff_temp(const std::string&) -> long double;

--- a/stargen.cpp
+++ b/stargen.cpp
@@ -1404,7 +1404,15 @@ void generate_stellar_system(StarGenerator* gen, sun &the_sun, bool use_seed_sys
   }
 
   if (the_sun.getEffTemp() == 0) {
-    the_sun.setEffTemp(spec_type_to_eff_temp(the_sun.getSpecType()));
+    // No spectral type or effective temperature was supplied (e.g. a mass- or
+    // luminosity-specified star). Derive the effective temperature from the
+    // physical mass-luminosity-temperature relation rather than from a defaulted
+    // spectral type, which previously floored it at ~273 K ("Y9V") and corrupted
+    // the temperature-dependent Kopparapu habitable zone. setEffTemp() then
+    // lazily derives the matching spectral type. See
+    // research/modern/07-stellar-relations-binaries.md.
+    the_sun.setEffTemp(
+        mass_to_eff_temp(the_sun.getMass(), the_sun.getLuminosity()));
   }
   gen->config.max_age = gen->config.max_age_backup;
   if (use_seed_system) {

--- a/tests/golden/stargen_seed_12345.txt
+++ b/tests/golden/stargen_seed_12345.txt
@@ -3,7 +3,7 @@ Stargen - V$Revision: 3.0 $; seed=12345
 Stellar mass: 1 solar masses
 Stellar luminosity: 0.98401110576113374486
 Age: 2.9435951718504091879 billion years	(7.2188917568565470887 billion left on main sequence)
-Habitable ecosphere radius: 1.1195233204889958 AU
+Habitable ecosphere radius: 1.2491693971174707 AU
 
 Planets present at:
 1	0.32929052848992333358 AU	0.056881742499426778893 EM	.
@@ -35,7 +35,7 @@ Planet is tidally locked with one face to star.
    Mass:			0.056881742499426778893 Earth masses
    Surface gravity:		0.3614652160721370886 Earth gees
    Surface pressure:		0 Earth atmospheres
-   Surface temperature:		192.70055394925742576 degrees Celcius
+   Surface temperature:		200.78923439505848592 degrees Celcius
    Boiling point of water:	-273.14999999999997726 degrees Celcius
    Hydrosphere percentage:	0%
    Cloud cover percentage:	0%
@@ -43,7 +43,7 @@ Planet is tidally locked with one face to star.
    Equatorial radius:		2695.469540671665163 Km
    Density:			4.144258000046801264 grams/cc
    Escape Velocity:		4.1024674329364200823 Km/sec
-   Molecular weight retained:	369.50032419051478963 and above
+   Molecular weight retained:	395.8393906087308779 and above
    Surface acceleration:	354.47628611938230486 cm/sec2
    Axial tilt:			0 degrees
    Planetary albedo:		0.07000000000000000666
@@ -58,7 +58,7 @@ Planet is tidally locked with one face to star.
    Mass:			0.004963935400002713156 Earth masses
    Surface gravity:		0.10786277766144842308 Earth gees
    Surface pressure:		0 Earth atmospheres
-   Surface temperature:		130.19758344239704684 degrees Celcius
+   Surface temperature:		137.20100907620445696 degrees Celcius
    Boiling point of water:	-273.14999999999997726 degrees Celcius
    Hydrosphere percentage:	0%
    Cloud cover percentage:	0%
@@ -66,7 +66,7 @@ Planet is tidally locked with one face to star.
    Equatorial radius:		1418.7067835930604833 Km
    Density:			2.4804207927771987465 grams/cc
    Escape Velocity:		1.6704852615393983433 Km/sec
-   Molecular weight retained:	1311.3340008579400529 and above
+   Molecular weight retained:	1404.8097330395817056 and above
    Surface acceleration:	105.777250855364313896 cm/sec2
    Axial tilt:			0 degrees
    Planetary albedo:		0.07000000000000000666
@@ -81,7 +81,7 @@ Planet is tidally locked with one face to star.
    Mass:			0.006096406370978955241 Earth masses
    Surface gravity:		0.14260381099132767619 Earth gees
    Surface pressure:		0 Earth atmospheres
-   Surface temperature:		121.14760700799104143 degrees Celcius
+   Surface temperature:		127.99389562264207143 degrees Celcius
    Boiling point of water:	-273.14999999999997726 degrees Celcius
    Hydrosphere percentage:	0%
    Cloud cover percentage:	0%
@@ -89,7 +89,7 @@ Planet is tidally locked with one face to star.
    Equatorial radius:		1445.449710184329556 Km
    Density:			2.880329201349892615 grams/cc
    Escape Velocity:		1.8340508450878140866 Km/sec
-   Molecular weight retained:	892.42246401410229983 and above
+   Molecular weight retained:	955.9852088730572337 and above
    Surface acceleration:	139.84656630581035039 cm/sec2
    Axial tilt:			0 degrees
    Planetary albedo:		0.07000000000000000666
@@ -104,7 +104,7 @@ Planet is tidally locked with one face to star.
    Mass:			0.06119851657504032232 Earth masses
    Surface gravity:		0.4153550613440611405 Earth gees
    Surface pressure:		0 Earth atmospheres
-   Surface temperature:		113.548861778586740456 degrees Celcius
+   Surface temperature:		120.26321146684034602 degrees Celcius
    Boiling point of water:	-273.14999999999997726 degrees Celcius
    Hydrosphere percentage:	0%
    Cloud cover percentage:	0%
@@ -112,7 +112,7 @@ Planet is tidally locked with one face to star.
    Equatorial radius:		2690.7952817807982593 Km
    Density:			4.4820438482206959277 grams/cc
    Escape Velocity:		4.2589842033388104754 Km/sec
-   Molecular weight retained:	153.26608034227349663 and above
+   Molecular weight retained:	164.19133589824252592 and above
    Surface acceleration:	407.32417123297370326 cm/sec2
    Axial tilt:			0 degrees
    Planetary albedo:		0.07000000000000000666
@@ -127,7 +127,7 @@ Planet is tidally locked with one face to star.
    Mass:			0.6397642960040522841 Earth masses
    Surface gravity:		1.2221995328418504867 Earth gees
    Surface pressure:		0 Earth atmospheres
-   Surface temperature:		16.657231911023904714 degrees Celcius
+   Surface temperature:		17.09664721092319889 degrees Celcius
    Boiling point of water:	-273.14999999999997726 degrees Celcius
    Hydrosphere percentage:	0%
    Cloud cover percentage:	99.22926533707410606%
@@ -135,7 +135,7 @@ Planet is tidally locked with one face to star.
    Equatorial radius:		5073.074741032417774 Km
    Density:			6.9917098191855810074 grams/cc
    Escape Velocity:		10.028830233224036638 Km/sec
-   Molecular weight retained:	16.917413003185117273 and above
+   Molecular weight retained:	17.020249556260539548 and above
    Surface acceleration:	1198.5683048743532632 cm/sec2
    Axial tilt:			0 degrees
    Planetary albedo:		0.516531694016833495
@@ -150,7 +150,7 @@ Planet is tidally locked with one face to star.
    Mass:			0.06394021786138123063 Earth masses
    Surface gravity:		0.47654443242343379138 Earth gees
    Surface pressure:		0 Earth atmospheres
-   Surface temperature:		49.193854951662501662 degrees Celcius
+   Surface temperature:		54.79079245504829032 degrees Celcius
    Boiling point of water:	-273.14999999999997726 degrees Celcius
    Hydrosphere percentage:	0%
    Cloud cover percentage:	0%
@@ -158,7 +158,7 @@ Planet is tidally locked with one face to star.
    Equatorial radius:		2655.043230257542212 Km
    Density:			4.874572112695911144 grams/cc
    Escape Velocity:		4.3825529090095747963 Km/sec
-   Molecular weight retained:	65.53317782822574544 and above
+   Molecular weight retained:	70.20457487556481806 and above
    Surface acceleration:	467.33044582252668167 cm/sec2
    Axial tilt:			0 degrees
    Planetary albedo:		0.07000000000000000666
@@ -172,7 +172,7 @@ Planet 7
    Mass:			0.15260228929772928803 Earth masses
    Surface gravity:		0.6186394958563824337 Earth gees
    Surface pressure:		0 Earth atmospheres
-   Surface temperature:		4.2680384392294286044 degrees Celcius
+   Surface temperature:		8.600600358432018311 degrees Celcius
    Boiling point of water:	-273.14999999999997726 degrees Celcius
    Hydrosphere percentage:	0%
    Cloud cover percentage:	0%
@@ -180,7 +180,7 @@ Planet 7
    Equatorial radius:		3463.0195350069608171 Km
    Density:			5.2429220741986463854 grams/cc
    Escape Velocity:		5.9282835001484502574 Km/sec
-   Molecular weight retained:	21.24306461330852923 and above
+   Molecular weight retained:	22.601527117659627679 and above
    Surface acceleration:	606.67810120399925683 cm/sec2
    Axial tilt:			130.16308419675237928 degrees
    Planetary albedo:		0.07000000000000000666
@@ -195,21 +195,22 @@ Cold for the habitable zone: outgassed CO2 may freeze out, risking irreversible 
    Mass:			0.34868708360437104053 Earth masses
    Surface gravity:		1.0302638288148448284 Earth gees
    Surface pressure:		0.15628955169226707571 Earth atmospheres
-   Surface temperature:		-80.555131097972364304 degrees Celcius
+   Surface temperature:		-78.43085786841563528 degrees Celcius
    Boiling point of water:	55.164916223671298212 degrees Celcius
    Hydrosphere percentage:	0%
-   Cloud cover percentage:	0.49251562604264359586%
+   Cloud cover percentage:	0.58633585351890394515%
    Ice cover percentage:	85.35713609471300715%
    Equatorial radius:		4206.9433105107871618 Km
    Density:			6.6821013561921666865 grams/cc
    Escape Velocity:		8.130373753353849752 Km/sec
-   Molecular weight retained:	5.6846243182973809314 and above
+   Molecular weight retained:	5.9039937851760130143 and above
    Surface acceleration:	1010.3436776847097662 cm/sec2
    Axial tilt:			105.99729353840434953 degrees
-   Planetary albedo:		0.6199321383656620122
+   Planetary albedo:		0.6200212675817644596
 
 
 Planet 9
+Cold for the habitable zone: outgassed CO2 may freeze out, risking irreversible glaciation.
    Distance from primary star:	1.5232573688759141364 AU
    Eccentricity of orbit:	0.013572953021888612194
    Length of year:		686.6831959988640101 days
@@ -217,156 +218,156 @@ Planet 9
    Mass:			1.3341239377847115686 Earth masses
    Surface gravity:		1.802909739249739854 Earth gees
    Surface pressure:		2.2172214402032715743 Earth atmospheres
-   Surface temperature:		-109.826952271156869756 degrees Celcius
+   Surface temperature:		-111.4047262436157079 degrees Celcius
    Boiling point of water:	123.56515664469952753 degrees Celcius
    Hydrosphere percentage:	0%
-   Cloud cover percentage:	0.36635735437953809935%
+   Cloud cover percentage:	0.29775376498456225578%
    Ice cover percentage:	100%
    Equatorial radius:		6123.691413768453956 Km
    Density:			8.289597850654847863 grams/cc
    Escape Velocity:		13.181576365106403828 Km/sec
-   Molecular weight retained:	1.5693681956625243523 and above
+   Molecular weight retained:	1.5102179428924362371 and above
    Surface acceleration:	1768.0504794413460684 cm/sec2
    Axial tilt:			65.943982781922741765 degrees
-   Planetary albedo:		0.6993405567621167873
+   Planetary albedo:		0.69946404322302774373
 
 
 Planet 10	*gas giant*
    Distance from primary star:	2.2760469761771999595 AU
    Eccentricity of orbit:	0.014571506181385933745
    Length of year:		1254.145286907297711 days
-   Length of day:		14.50651522233658608 hours
+   Length of day:		14.573735191654934667 hours
    Mass:			32.705540882521099498 Earth masses
-   Equatorial radius:		53658.48606644879493 Km
-   Density:			0.30205307995616158836 grams/cc
-   Escape Velocity:		28.823270706243454478 Km/sec
+   Equatorial radius:		52044.205329933751912 Km
+   Density:			0.3310406829338612272 grams/cc
+   Escape Velocity:		28.756720956383538432 Km/sec
    Molecular weight retained:	0.54613249979630363093 and above
-   Surface acceleration:	1303.4267704118172677 cm/sec2
+   Surface acceleration:	1291.4305234204351112 cm/sec2
    Axial tilt:			112.91101876386278491 degrees
-   Planetary albedo:		0.097135270458149148194
+   Planetary albedo:		0.69195595406948757046
 
 
 Planet 11
    Distance from primary star:	3.0651501624522978849 AU
    Eccentricity of orbit:	0.17813163723997674784
    Length of year:		1960.0836590924733526 days
-   Length of day:		19.539516429601885077 hours
+   Length of day:		17.262740718132761033 hours
    Mass:			0.58856339012300186014 Earth masses
-   Surface gravity:		0.54985401862815242455 Earth gees
-   Surface pressure:		0.25600662731955974198 Earth atmospheres
-   Surface temperature:		-148.41457306025508936 degrees Celcius
-   Boiling point of water:	66.04640782783309305 degrees Celcius
+   Surface gravity:		1.1186641583943153742 Earth gees
+   Surface pressure:		0.40652564143020255175 Earth atmospheres
+   Surface temperature:		-157.75134164843938814 degrees Celcius
+   Boiling point of water:	76.91890355234352228 degrees Celcius
    Hydrosphere percentage:	0%
-   Cloud cover percentage:	0.0011506949391284858348%
-   Ice cover percentage:	79.23777868333515812%
-   Equatorial radius:		5672.821568058297202 Km
-   Density:			4.6001612166033575926 grams/cc
-   Escape Velocity:		9.096471662710857345 Km/sec
-   Molecular weight retained:	1.3564550886930928505 and above
-   Surface acceleration:	539.2225911779770774 cm/sec2
-   Axial tilt:			81.55638191190649877 degrees
-   Planetary albedo:		0.58580887591853550536
+   Cloud cover percentage:	0.0014201847854966342392%
+   Ice cover percentage:	100%
+   Equatorial radius:		5011.7722974743930155 Km
+   Density:			6.671084306525173776 grams/cc
+   Escape Velocity:		9.677804998329255032 Km/sec
+   Molecular weight retained:	0.80802717604320322884 and above
+   Surface acceleration:	1097.0347868917612458 cm/sec2
+   Axial tilt:			58.130838431620155404 degrees
+   Planetary albedo:		0.6999974436673860616
 
 
 Planet 12	*gas giant*
    Distance from primary star:	4.4095270134381198187 AU
    Eccentricity of orbit:	0.0082023864671672274155
    Length of year:		3382.0823583910567438 days
-   Length of day:		27.964375600658941444 hours
+   Length of day:		28.02296921185798182 hours
    Mass:			1.8251045386066755698 Earth masses
-   Equatorial radius:		29344.608838151609318 Km
-   Density:			0.103057582114784684675 grams/cc
-   Escape Velocity:		10.089907026993377367 Km/sec
-   Molecular weight retained:	0.56823143011068100806 and above
-   Surface acceleration:	250.20927114693932411 cm/sec2
-   Axial tilt:			16.425025528810063946 degrees
-   Planetary albedo:		0.07519705148470756769
+   Equatorial radius:		27931.176042876345269 Km
+   Density:			0.119508076701885641095 grams/cc
+   Escape Velocity:		10.079352927165185101 Km/sec
+   Molecular weight retained:	0.40614298115698721096 and above
+   Surface acceleration:	347.6589267531330363 cm/sec2
+   Axial tilt:			44.719731576225939307 degrees
+   Planetary albedo:		0.56634259253757936674
 
 
 Planet 13	*gas giant*
    Distance from primary star:	6.726454872456255304 AU
    Eccentricity of orbit:	0.013574670721917439509
    Length of year:		6365.7777920396335047 days
-   Length of day:		8.510959202277784471 hours
+   Length of day:		8.550397467820385666 hours
    Mass:			652.3035700326716637 Earth masses
-   Equatorial radius:		72227.70002488735292 Km
-   Density:			2.470105920725875865 grams/cc
-   Escape Velocity:		79.522608448315551505 Km/sec
-   Molecular weight retained:	0.470854873457733559 and above
-   Surface acceleration:	4846.664451354684267 cm/sec2
-   Axial tilt:			92.02564688856747921 degrees
-   Planetary albedo:		0.079560180485125026134
+   Equatorial radius:		72018.145001853082626 Km
+   Density:			2.4917309175677473394 grams/cc
+   Escape Velocity:		79.33899952501258813 Km/sec
+   Molecular weight retained:	0.5406655844802810366 and above
+   Surface acceleration:	3238.1043336573698312 cm/sec2
+   Axial tilt:			33.078347816457352337 degrees
+   Planetary albedo:		0.49297464843539304976
 
 
 Planet 14
    Distance from primary star:	13.648180577000076059 AU
    Eccentricity of orbit:	0
    Length of year:		18416.581102034145806 days
-   Length of day:		17.869518953026788614 hours
+   Length of day:		18.702326805322549185 hours
    Mass:			0.7490587732460501819 Earth masses
-   Surface gravity:		0.81576801560142986824 Earth gees
-   Surface pressure:		0.26150205094810797997 Earth atmospheres
-   Surface temperature:		-218.61711988572862946 degrees Celcius
-   Boiling point of water:	66.530934736608628555 degrees Celcius
+   Surface gravity:		0.67119971765994387934 Earth gees
+   Surface pressure:		0.22496655414545844487 Earth atmospheres
+   Surface temperature:		-218.68170860007346334 degrees Celcius
+   Boiling point of water:	63.127298835559713552 degrees Celcius
    Hydrosphere percentage:	0%
-   Cloud cover percentage:	4.3950872631357646637e-06%
+   Cloud cover percentage:	4.1808836054526072766e-06%
    Ice cover percentage:	100%
-   Equatorial radius:		5853.124501963980145 Km
-   Density:			5.3300316384483195954 grams/cc
-   Escape Velocity:		10.10275862323748297 Km/sec
-   Molecular weight retained:	0.05916353596327398832 and above
-   Surface acceleration:	799.99514101977619207 cm/sec2
-   Axial tilt:			56.343969797334494842 degrees
-   Planetary albedo:		0.69999999208884288197
+   Equatorial radius:		6125.9090180713033713 Km
+   Density:			4.649234438509538937 grams/cc
+   Escape Velocity:		9.875261091485113139 Km/sec
+   Molecular weight retained:	0.06162801376665732119 and above
+   Surface acceleration:	658.22207111898884 cm/sec2
+   Axial tilt:			58.175665282195382133 degrees
+   Planetary albedo:		0.6999999924744094658
 
 
 Planet 15	*gas giant*
    Distance from primary star:	18.997848568563493705 AU
    Eccentricity of orbit:	0.1276726960001111355
    Length of year:		30244.772765580602988 days
-   Length of day:		24.989211956402799535 hours
+   Length of day:		25.08412678938768658 hours
    Mass:			5.61696320492433811 Earth masses
-   Equatorial radius:		43556.519254267908003 Km
-   Density:			0.09698827999071751781 grams/cc
-   Escape Velocity:		14.137302365960266907 Km/sec
-   Molecular weight retained:	0.0155934301475418022085 and above
-   Surface acceleration:	439.87613835575510088 cm/sec2
-   Axial tilt:			74.082202736207818816 degrees
-   Planetary albedo:		0.31302438463093353139
+   Equatorial radius:		46738.751954401357697 Km
+   Density:			0.07849598127752506237 grams/cc
+   Escape Velocity:		14.110530227447829675 Km/sec
+   Molecular weight retained:	0.057165478022198691227 and above
+   Surface acceleration:	105.57862493321802302 cm/sec2
+   Axial tilt:			151.67747771466338236 degrees
+   Planetary albedo:		0.29612447769362602247
 
 
 Planet 16	*gas giant*
    Distance from primary star:	26.744272453248485406 AU
    Eccentricity of orbit:	0.00343392519934015354
    Length of year:		50517.515723690898902 days
-   Length of day:		30.738959704740632845 hours
+   Length of day:		30.816081388072626283 hours
    Mass:			2.3835069451012859004 Earth masses
-   Equatorial radius:		39347.148449151468977 Km
-   Density:			0.05582822350828211546 grams/cc
-   Escape Velocity:		10.287905228912121384 Km/sec
-   Molecular weight retained:	0.02971653070273890593 and above
-   Surface acceleration:	187.25130251294751736 cm/sec2
-   Axial tilt:			144.42076601789270285 degrees
-   Planetary albedo:		0.30383566353509710157
+   Equatorial radius:		39458.05948541599176 Km
+   Density:			0.055358769781930621956 grams/cc
+   Escape Velocity:		10.275023681876668706 Km/sec
+   Molecular weight retained:	0.02805229703018419299 and above
+   Surface acceleration:	116.848908779696055 cm/sec2
+   Axial tilt:			36.617616843769475565 degrees
+   Planetary albedo:		0.29459421079507890605
 
 
 Planet 17
    Distance from primary star:	44.658659885913400953 AU
    Eccentricity of orbit:	0.15675788795391934483
    Length of year:		109007.2291973598898 days
-   Length of day:		18.265706098634100715 hours
+   Length of day:		24.553817206351630276 hours
    Mass:			0.90120455136914300455 Earth masses
-   Surface gravity:		0.5107901134760775856 Earth gees
-   Surface pressure:		0.12062466253262446872 Earth atmospheres
-   Surface temperature:		-235.57392314402728317 degrees Celcius
-   Boiling point of water:	49.728166699220651026 degrees Celcius
+   Surface gravity:		0.13225627383555945777 Earth gees
+   Surface pressure:		0.052727225047579766904 Earth atmospheres
+   Surface temperature:		-243.14449844593147176 degrees Celcius
+   Boiling point of water:	33.504505816578159738 degrees Celcius
    Hydrosphere percentage:	0%
-   Cloud cover percentage:	2.8805497689963078462e-07%
-   Ice cover percentage:	22.891947924602271477%
-   Equatorial radius:		6562.436436346763081 Km
-   Density:			4.54993534202188443 grams/cc
-   Escape Velocity:		10.465380997900370276 Km/sec
-   Molecular weight retained:	0.010298930578808916676 and above
-   Surface acceleration:	500.9139866320176069 cm/sec2
-   Axial tilt:			125.09376369865780987 degrees
-   Planetary albedo:		0.27590571385896470676
+   Cloud cover percentage:	1.4556794577617124916e-07%
+   Ice cover percentage:	100%
+   Equatorial radius:		8821.606118944703709 Km
+   Density:			1.8730853461544708523 grams/cc
+   Escape Velocity:		9.026383208267169539 Km/sec
+   Molecular weight retained:	0.027172923439864086944 and above
+   Surface acceleration:	129.69909878094891084 cm/sec2
+   Axial tilt:			75.62917950546057 degrees
+   Planetary albedo:		0.69999999973797765314

--- a/tests/golden/stargen_seed_42.txt
+++ b/tests/golden/stargen_seed_42.txt
@@ -3,14 +3,14 @@ Stargen - V$Revision: 3.0 $; seed=42
 Stellar mass: 1 solar masses
 Stellar luminosity: 0.98401110576113374486
 Age: 7.5663580299171949166 billion years	(2.5961288987897613602 billion left on main sequence)
-Habitable ecosphere radius: 1.1195233204889958 AU
+Habitable ecosphere radius: 1.2491693971174707 AU
 
 Planets present at:
 1	0.3556694362521560706 AU	0.03519412665792341447 EM	.
 2	0.42887140693515651837 AU	0.065021642960036551685 EM	.
 3	0.55768756950593494423 AU	0.4055982691315685622 EM	o
 4	0.9615657911871555064 AU	0.70275157781690689954 EM	*
-5	1.4462026994367287258 AU	3.1032148593715900868 EM	*
+5	1.4462026994367287258 AU	3.1032148593715900868 EM	o
 6	1.9426215771489064492 AU	0.27758054499394701307 EM	o
 7	3.103655350167082982 AU	159.64472935996509803 EM	o
 8	4.803139846391668188 AU	0.09870640215674023548 EM	.
@@ -30,7 +30,7 @@ Planet is tidally locked with one face to star.
    Mass:			0.03519412665792341447 Earth masses
    Surface gravity:		0.3404267003897274555 Earth gees
    Surface pressure:		0 Earth atmospheres
-   Surface temperature:		175.09242863588809769 degrees Celcius
+   Surface temperature:		182.87537476903878542 degrees Celcius
    Boiling point of water:	-273.14999999999997726 degrees Celcius
    Hydrosphere percentage:	0%
    Cloud cover percentage:	0%
@@ -38,7 +38,7 @@ Planet is tidally locked with one face to star.
    Equatorial radius:		2290.0819068163998704 Km
    Density:			4.181136290630104019 grams/cc
    Escape Velocity:		3.5009467005458375206 Km/sec
-   Molecular weight retained:	407.01421856689921264 and above
+   Molecular weight retained:	436.02738536039948763 and above
    Surface acceleration:	333.84455013769206275 cm/sec2
    Axial tilt:			0 degrees
    Planetary albedo:		0.07000000000000000666
@@ -53,7 +53,7 @@ Planet is tidally locked with one face to star.
    Mass:			0.065021642960036551685 Earth masses
    Surface gravity:		0.32699448701286721575 Earth gees
    Surface pressure:		0 Earth atmospheres
-   Surface temperature:		135.04970781497866028 degrees Celcius
+   Surface temperature:		142.13738210578651433 degrees Celcius
    Boiling point of water:	-273.14999999999997726 degrees Celcius
    Hydrosphere percentage:	0%
    Cloud cover percentage:	0%
@@ -61,7 +61,7 @@ Planet is tidally locked with one face to star.
    Equatorial radius:		2882.5183398758885676 Km
    Density:			3.8736366381098576005 grams/cc
    Escape Velocity:		4.241493837597593665 Km/sec
-   Molecular weight retained:	230.63240548344086708 and above
+   Molecular weight retained:	247.07255951992058972 and above
    Surface acceleration:	320.67204860647341624 cm/sec2
    Axial tilt:			0 degrees
    Planetary albedo:		0.07000000000000000666
@@ -76,7 +76,7 @@ Planet is tidally locked with one face to star.
    Mass:			0.4055982691315685622 Earth masses
    Surface gravity:		0.7899638874045976918 Earth gees
    Surface pressure:		0 Earth atmospheres
-   Surface temperature:		84.815154931559050056 degrees Celcius
+   Surface temperature:		87.625632933297481486 degrees Celcius
    Boiling point of water:	-273.14999999999997726 degrees Celcius
    Hydrosphere percentage:	0%
    Cloud cover percentage:	0%
@@ -84,7 +84,7 @@ Planet is tidally locked with one face to star.
    Equatorial radius:		4693.5717024349824786 Km
    Density:			5.5970978664903945597 grams/cc
    Escape Velocity:		8.301799273515724344 Km/sec
-   Molecular weight retained:	34.898307505905043942 and above
+   Molecular weight retained:	36.007265408135939712 and above
    Surface acceleration:	774.68993564162976667 cm/sec2
    Axial tilt:			0 degrees
    Planetary albedo:		0.07000000000000000666
@@ -98,40 +98,41 @@ Planet 4
    Mass:			0.70275157781690689954 Earth masses
    Surface gravity:		1.431288968348296826 Earth gees
    Surface pressure:		0.6374057465478117838 Earth atmospheres
-   Surface temperature:		11.1276390417208729255 degrees Celcius
+   Surface temperature:		10.7266597384680653915 degrees Celcius
    Boiling point of water:	88.18328607380306039 degrees Celcius
    Hydrosphere percentage:	78.73600166173135274%
-   Cloud cover percentage:	45.04321524752556683%
-   Ice cover percentage:	2.9920822800950746538%
+   Cloud cover percentage:	43.785100508583591383%
+   Ice cover percentage:	3.141200265705741779%
    Equatorial radius:		5077.351779182848753 Km
    Density:			7.6606786566112598505 grams/cc
    Escape Velocity:		10.506503222525771707 Km/sec
-   Molecular weight retained:	6.02694545715449487 and above
+   Molecular weight retained:	6.0255179629751864645 and above
    Surface acceleration:	1403.6149961452824548 cm/sec2
    Axial tilt:			162.12711989020007763 degrees
-   Planetary albedo:		0.26526888829976791656
+   Planetary albedo:		0.2690151310106037725
 
 
 Planet 5
+Cold for the habitable zone: outgassed CO2 may freeze out, risking irreversible glaciation.
    Distance from primary star:	1.4462026994367287258 AU
    Eccentricity of orbit:	0.04843620426840152801
    Length of year:		635.2418261590967404 days
    Length of day:		11.409088167542811663 hours
    Mass:			3.1032148593715900868 Earth masses
    Surface gravity:		2.8594120784365364178 Earth gees
-   Surface pressure:		12.495064931350600777 Earth atmospheres
-   Surface temperature:		4.768107587905320327 degrees Celcius
+   Surface pressure:		5.7630024821667538153 Earth atmospheres
+   Surface temperature:		-108.256313147436420266 degrees Celcius
    Boiling point of water:	185.91467735562815733 degrees Celcius
-   Hydrosphere percentage:	70.370370370370370364%
-   Cloud cover percentage:	28.057490061796168295%
-   Ice cover percentage:	9.684797543841038901%
+   Hydrosphere percentage:	0%
+   Cloud cover percentage:	1.0790543747944355122%
+   Ice cover percentage:	100%
    Equatorial radius:		7568.6566735616223713 Km
    Density:			10.2125126681984102735 grams/cc
    Escape Velocity:		18.0830811319828243 Km/sec
-   Molecular weight retained:	0.9251303425212567291 and above
+   Molecular weight retained:	0.8627693597124472528 and above
    Surface acceleration:	2804.125345899965882 cm/sec2
    Axial tilt:			75.14741740661810354 degrees
-   Planetary albedo:		0.22440583856336268842
+   Planetary albedo:		0.69805770212536997235
 
 
 Planet 6
@@ -141,120 +142,120 @@ Planet 6
    Length of day:		24.04925141997158226 hours
    Mass:			0.27758054499394701307 Earth masses
    Surface gravity:		0.30082927485462657456 Earth gees
-   Surface pressure:		0.04677986926523522024 Earth atmospheres
-   Surface temperature:		-104.214631634607419144 degrees Celcius
+   Surface pressure:		0.18376094856982558291 Earth atmospheres
+   Surface temperature:		-102.245968543639349946 degrees Celcius
    Boiling point of water:	31.29223807135434754 degrees Celcius
    Hydrosphere percentage:	0%
-   Cloud cover percentage:	0.0110272178321147533725%
+   Cloud cover percentage:	0.013398577726618442384%
    Ice cover percentage:	52.770201083183883323%
    Equatorial radius:		4773.8501764642771152 Km
    Density:			3.6404900441029889265 grams/cc
    Escape Velocity:		6.8098262317467993126 Km/sec
-   Molecular weight retained:	7.33124959290120948 and above
+   Molecular weight retained:	7.6790350587593520695 and above
    Surface acceleration:	295.0127408253123588 cm/sec2
    Axial tilt:			135.1064706665518429 degrees
-   Planetary albedo:		0.44024658181445184126
+   Planetary albedo:		0.44024883460635161976
 
 
 Planet 7	*gas giant*
    Distance from primary star:	3.103655350167082982 AU
    Eccentricity of orbit:	0.024769427950353692608
    Length of year:		1996.6568977103012942 days
-   Length of day:		10.6989065419145865385 hours
+   Length of day:		10.7484833130800768826 hours
    Mass:			159.64472935996509803 Earth masses
-   Equatorial radius:		65299.395933053207873 Km
-   Density:			0.8180960051639411765 grams/cc
-   Escape Velocity:		49.886910462000621482 Km/sec
+   Equatorial radius:		64561.584852679357386 Km
+   Density:			0.846465407729891103 grams/cc
+   Escape Velocity:		49.771727093452131377 Km/sec
    Molecular weight retained:	0.49422987560448737793 and above
-   Surface acceleration:	2841.9313357831454654 cm/sec2
+   Surface acceleration:	2815.775274690559798 cm/sec2
    Axial tilt:			137.40097724864128281 degrees
-   Planetary albedo:		0.08449190559832032668
+   Planetary albedo:		0.52977460374058837775
 
 
 Planet 8
    Distance from primary star:	4.803139846391668188 AU
    Eccentricity of orbit:	0.0363329853968809317
    Length of year:		3844.9008212039289005 days
-   Length of day:		29.978039390447176946 hours
+   Length of day:		33.607717318763703884 hours
    Mass:			0.09870640215674023548 Earth masses
-   Surface gravity:		0.23896339239079111486 Earth gees
-   Surface pressure:		0.0035432814297826623764 Earth atmospheres
-   Surface temperature:		-181.22508827065981526 degrees Celcius
-   Boiling point of water:	-9.688083485097820358 degrees Celcius
+   Surface gravity:		0.09844608799913469765 Earth gees
+   Surface pressure:		0.0018364154605687201577 Earth atmospheres
+   Surface temperature:		-179.62897337047714075 degrees Celcius
+   Boiling point of water:	-18.421486498712340563 degrees Celcius
    Hydrosphere percentage:	0%
-   Cloud cover percentage:	3.8300432040815328733e-05%
+   Cloud cover percentage:	3.484871683971505892e-05%
    Ice cover percentage:	100%
-   Equatorial radius:		3564.2960705399786665 Km
-   Density:			3.1102921553814722236 grams/cc
-   Escape Velocity:		4.6996085540479799964 Km/sec
-   Molecular weight retained:	2.0695743719787241394 and above
-   Surface acceleration:	234.34303519891515996 cm/sec2
-   Axial tilt:			126.412585009919169465 degrees
-   Planetary albedo:		0.6999999310592222821
+   Equatorial radius:		3995.872491032927032 Km
+   Density:			2.2074335368008081457 grams/cc
+   Escape Velocity:		4.4385668049677455566 Km/sec
+   Molecular weight retained:	4.6396994117184253282 and above
+   Surface acceleration:	96.542632887671424695 cm/sec2
+   Axial tilt:			85.65249885013878384 degrees
+   Planetary albedo:		0.6999999372723096441
 
 
 Planet 9	*gas giant*
    Distance from primary star:	7.4004806764832269457 AU
    Eccentricity of orbit:	0.032524431387204546173
    Length of year:		7345.088531209174801 days
-   Length of day:		8.328257103220170711 hours
+   Length of day:		8.3668487598389815595 hours
    Mass:			752.10120006876090143 Earth masses
-   Equatorial radius:		70851.5948357787046 Km
-   Density:			3.0172032617899600473 grams/cc
-   Escape Velocity:		83.302769657232249155 Km/sec
-   Molecular weight retained:	0.5090263933238804672 and above
-   Surface acceleration:	3528.7518653281885963 cm/sec2
-   Axial tilt:			59.673952359167131476 degrees
-   Planetary albedo:		0.08501583271510309258
+   Equatorial radius:		70451.996942242612185 Km
+   Density:			3.0688349897282718812 grams/cc
+   Escape Velocity:		83.11043275904234499 Km/sec
+   Molecular weight retained:	0.5156983854782689041 and above
+   Surface acceleration:	3133.6651239475841828 cm/sec2
+   Axial tilt:			82.327732939078117624 degrees
+   Planetary albedo:		0.5239454482894993764
 
 
 Planet 10
    Distance from primary star:	12.278965818860191272 AU
    Eccentricity of orbit:	0.028901475546966694469
    Length of year:		15715.914350338152215 days
-   Length of day:		23.042949493135347459 hours
+   Length of day:		18.176281873683297945 hours
    Mass:			0.5993139392335517376 Earth masses
-   Surface gravity:		0.266399461443805583 Earth gees
-   Surface pressure:		0.08043205986674068893 Earth atmospheres
-   Surface temperature:		-215.65700677872946282 degrees Celcius
-   Boiling point of water:	41.573999777198253014 degrees Celcius
+   Surface gravity:		0.84376448008023437495 Earth gees
+   Surface pressure:		0.18467232360643421154 Earth atmospheres
+   Surface temperature:		-215.51005965423896053 degrees Celcius
+   Boiling point of water:	58.76546645823941617 degrees Celcius
    Hydrosphere percentage:	0%
-   Cloud cover percentage:	3.8251558794126944725e-06%
+   Cloud cover percentage:	5.3419436929557035324e-06%
    Ice cover percentage:	100%
-   Equatorial radius:		6751.2190447153456727 Km
-   Density:			2.7789770500286697199 grams/cc
-   Escape Velocity:		8.414183913359262515 Km/sec
-   Molecular weight retained:	0.1580619273254200741 and above
-   Surface acceleration:	261.24862785678959234 cm/sec2
-   Axial tilt:			44.914932235968912266 degrees
-   Planetary albedo:		0.69999999311471937266
+   Equatorial radius:		5325.362505213948469 Km
+   Density:			5.6621846574893351946 grams/cc
+   Escape Velocity:		9.47389379379290971 Km/sec
+   Molecular weight retained:	0.08397256119331428291 and above
+   Surface acceleration:	827.4502938578830126 cm/sec2
+   Axial tilt:			151.94237917546814742 degrees
+   Planetary albedo:		0.6999999903845013083
 
 
 Planet 11	*gas giant*
    Distance from primary star:	22.58166126909659726 AU
    Eccentricity of orbit:	0.15807503662779803788
    Length of year:		39193.61160320925956 days
-   Length of day:		18.672142297952891729 hours
+   Length of day:		18.758665672059562434 hours
    Mass:			24.378251021053557814 Earth masses
-   Equatorial radius:		40796.54658182911582 Km
-   Density:			0.51228249701974467803 grams/cc
-   Escape Velocity:		23.605923439876032062 Km/sec
-   Molecular weight retained:	0.4822094702719925725 and above
-   Surface acceleration:	438.37740101078818358 cm/sec2
-   Axial tilt:			31.221759670780894425 degrees
-   Planetary albedo:		0.31296698932447732382
+   Equatorial radius:		39713.92738264801766 Km
+   Density:			0.55533009626213976 grams/cc
+   Escape Velocity:		23.551419968838798813 Km/sec
+   Molecular weight retained:	0.46242199681318435262 and above
+   Surface acceleration:	605.9917709100457482 cm/sec2
+   Axial tilt:			53.253059174045958457 degrees
+   Planetary albedo:		0.31560451065485191767
 
 
 Planet 12	*gas giant*
    Distance from primary star:	40.035451774660471627 AU
    Eccentricity of orbit:	0.13797317233497885525
    Length of year:		92525.851263507627564 days
-   Length of day:		32.642672175818896914 hours
+   Length of day:		32.718167866003221207 hours
    Mass:			2.0991265330649087684 Earth masses
-   Equatorial radius:		37800.77430332134729 Km
-   Density:			0.055451552356424556528 grams/cc
-   Escape Velocity:		9.671286192137215985 Km/sec
-   Molecular weight retained:	0.0150056790754407239454 and above
-   Surface acceleration:	115.83890620832350264 cm/sec2
-   Axial tilt:			66.27619146566983943 degrees
-   Planetary albedo:		0.30613730482936731884
+   Equatorial radius:		37778.628376553482784 Km
+   Density:			0.055549127050084658255 grams/cc
+   Escape Velocity:		9.660121720654995879 Km/sec
+   Molecular weight retained:	0.014229196596225863998 and above
+   Surface acceleration:	122.5716976388019723 cm/sec2
+   Axial tilt:			96.084951240891584234 degrees
+   Planetary albedo:		0.30883842923279291435

--- a/tests/golden/stargen_seed_7.txt
+++ b/tests/golden/stargen_seed_7.txt
@@ -3,7 +3,7 @@ Stargen - V$Revision: 3.0 $; seed=7
 Stellar mass: 1 solar masses
 Stellar luminosity: 0.98401110576113374486
 Age: 7.21457059109049871 billion years	(2.9479163376164575665 billion left on main sequence)
-Habitable ecosphere radius: 1.1195233204889958 AU
+Habitable ecosphere radius: 1.2491693971174707 AU
 
 Planets present at:
 1	0.31352621900625999072 AU	0.055771788683812297612 EM	.
@@ -28,7 +28,7 @@ Planet is tidally locked with one face to star.
    Mass:			0.055771788683812297612 Earth masses
    Surface gravity:		0.34327476470523682654 Earth gees
    Surface pressure:		0 Earth atmospheres
-   Surface temperature:		204.26856521860355542 degrees Celcius
+   Surface temperature:		212.55810395631374377 degrees Celcius
    Boiling point of water:	-273.14999999999997726 degrees Celcius
    Hydrosphere percentage:	0%
    Cloud cover percentage:	0%
@@ -36,7 +36,7 @@ Planet is tidally locked with one face to star.
    Equatorial radius:		2703.7423708258499369 Km
    Density:			4.0262045050958638697 grams/cc
    Escape Velocity:		4.0560242560518177924 Km/sec
-   Molecular weight retained:	438.3761921701094487 and above
+   Molecular weight retained:	469.62493238983335925 and above
    Surface acceleration:	336.63754712966106 cm/sec2
    Axial tilt:			0 degrees
    Planetary albedo:		0.07000000000000000666
@@ -51,7 +51,7 @@ Planet's rotation is in a resonant spin lock with the star.
    Mass:			0.5707127415151546829 Earth masses
    Surface gravity:		1.3143682828764681701 Earth gees
    Surface pressure:		0 Earth atmospheres
-   Surface temperature:		102.37165902612963464 degrees Celcius
+   Surface temperature:		103.612559662080855105 degrees Celcius
    Boiling point of water:	-273.14999999999997726 degrees Celcius
    Hydrosphere percentage:	0%
    Cloud cover percentage:	0%
@@ -59,7 +59,7 @@ Planet's rotation is in a resonant spin lock with the star.
    Equatorial radius:		4788.017305828775196 Km
    Density:			7.418696637772655516 grams/cc
    Escape Velocity:		9.750049913249480305 Km/sec
-   Molecular weight retained:	25.017261793913453206 and above
+   Molecular weight retained:	25.349579787192582883 and above
    Surface acceleration:	1288.9549721270516103 cm/sec2
    Axial tilt:			14.128921366628834022 degrees
    Planetary albedo:		0.07000000000000000666
@@ -74,7 +74,7 @@ Planet is tidally locked with one face to star.
    Mass:			0.08721797189763170687 Earth masses
    Surface gravity:		0.21210877619241586665 Earth gees
    Surface pressure:		0 Earth atmospheres
-   Surface temperature:		21.873265123607097848 degrees Celcius
+   Surface temperature:		26.995828347867188768 degrees Celcius
    Boiling point of water:	-273.14999999999997726 degrees Celcius
    Hydrosphere percentage:	0%
    Cloud cover percentage:	0%
@@ -82,7 +82,7 @@ Planet is tidally locked with one face to star.
    Equatorial radius:		3412.736311939526772 Km
    Density:			3.1309415615242441968 grams/cc
    Escape Velocity:		4.514685848099218565 Km/sec
-   Molecular weight retained:	81.22737031693152249 and above
+   Molecular weight retained:	87.01749541747563335 and above
    Surface acceleration:	208.00765300473549815 cm/sec2
    Axial tilt:			0 degrees
    Planetary albedo:		0.07000000000000000666
@@ -96,119 +96,119 @@ Planet 4
    Mass:			1.9170235954703192081 Earth masses
    Surface gravity:		2.370090445359390402 Earth gees
    Surface pressure:		4.8573296165152146245 Earth atmospheres
-   Surface temperature:		12.49800354954195325 degrees Celcius
+   Surface temperature:		11.246606019104955471 degrees Celcius
    Boiling point of water:	149.6075865504276976 degrees Celcius
-   Hydrosphere percentage:	95.122694711172077434%
-   Cloud cover percentage:	60.93117016020856228%
-   Ice cover percentage:	3.9916862374258740575%
+   Hydrosphere percentage:	93.41563786008230453%
+   Cloud cover percentage:	55.751282621527859674%
+   Ice cover percentage:	4.0634348175048564727%
    Equatorial radius:		6594.721236188012762 Km
    Density:			9.537077453588382914 grams/cc
    Escape Velocity:		15.226196087268623523 Km/sec
-   Molecular weight retained:	2.2301931968526450467 and above
+   Molecular weight retained:	2.1170414191053176576 and above
    Surface acceleration:	2324.2647465983665025 cm/sec2
    Axial tilt:			131.19832162136182774 degrees
-   Planetary albedo:		0.35701724343271983703
+   Planetary albedo:		0.32921386276640351507
 
 
 Planet 5	*gas giant*
    Distance from primary star:	2.2704109662780684606 AU
    Eccentricity of orbit:	0.16536867296144835282
    Length of year:		1249.5177934578438476 days
-   Length of day:		16.459964304781385723 hours
+   Length of day:		16.53623395266104701 hours
    Mass:			17.819444607061895997 Earth masses
-   Equatorial radius:		39592.46654466170955 Km
-   Density:			0.40966953310959813275 grams/cc
-   Escape Velocity:		23.247954748922432773 Km/sec
+   Equatorial radius:		39182.90497467777339 Km
+   Density:			0.42265056060574471584 grams/cc
+   Escape Velocity:		23.194277788071483373 Km/sec
    Molecular weight retained:	0.5138732321540121599 and above
-   Surface acceleration:	1317.8089253115710252 cm/sec2
+   Surface acceleration:	1305.6803104063465291 cm/sec2
    Axial tilt:			57.700010896413225225 degrees
-   Planetary albedo:		0.08794636674003114608
+   Planetary albedo:		0.7250088166052164684
 
 
 Planet 6	*gas giant*
    Distance from primary star:	4.6111487314583936383 AU
    Eccentricity of orbit:	0.06472317548282343475
    Length of year:		3614.1837382443345015 days
-   Length of day:		8.864502359593441306 hours
+   Length of day:		8.905578879471576206 hours
    Mass:			461.33340899326759296 Earth masses
-   Equatorial radius:		70770.615774478267134 Km
-   Density:			1.8570908989318242634 grams/cc
-   Escape Velocity:		71.45686972884759307 Km/sec
-   Molecular weight retained:	0.46860179990157329035 and above
-   Surface acceleration:	1618.5062406807054026 cm/sec2
-   Axial tilt:			65.79962314833117887 degrees
-   Planetary albedo:		0.07600438475314364071
+   Equatorial radius:		70577.504557065431406 Km
+   Density:			1.8723765300907291438 grams/cc
+   Escape Velocity:		71.291883705759057775 Km/sec
+   Molecular weight retained:	0.5110267558555445101 and above
+   Surface acceleration:	2502.0369142456411617 cm/sec2
+   Axial tilt:			82.97144365737486282 degrees
+   Planetary albedo:		0.60093736525680339244
 
 
 Planet 7	*gas giant*
    Distance from primary star:	11.598752025745930624 AU
    Eccentricity of orbit:	0.084224604222405489106
    Length of year:		14413.040235385907002 days
-   Length of day:		8.766872108812357276 hours
+   Length of day:		8.807496229122457044 hours
    Mass:			703.62649732524165946 Earth masses
-   Equatorial radius:		70897.76990023865215 Km
-   Density:			2.8172256918665285258 grams/cc
-   Escape Velocity:		79.851052201864765955 Km/sec
-   Molecular weight retained:	0.5403257646087370956 and above
-   Surface acceleration:	3577.8221995302317815 cm/sec2
-   Axial tilt:			152.14227291220413463 degrees
-   Planetary albedo:		0.06970031433125197809
+   Equatorial radius:		70706.15000457285814 Km
+   Density:			2.8401926113998359443 grams/cc
+   Escape Velocity:		79.666684938196316364 Km/sec
+   Molecular weight retained:	0.5064235737581373343 and above
+   Surface acceleration:	2893.2241564142565946 cm/sec2
+   Axial tilt:			90.881445176781056716 degrees
+   Planetary albedo:		0.34630804558298413056
 
 
 Planet 8	*gas giant*
    Distance from primary star:	16.084340240521843244 AU
    Eccentricity of orbit:	0.056649266129099651312
    Length of year:		23561.165375476410265 days
-   Length of day:		22.674089889204775703 hours
+   Length of day:		22.77341251515869049 hours
    Mass:			8.380116491038893308 Earth masses
-   Equatorial radius:		37586.546918475998417 Km
-   Density:			0.22518006878903896537 grams/cc
-   Escape Velocity:		16.402687629575310275 Km/sec
-   Molecular weight retained:	0.016160212390331134522 and above
-   Surface acceleration:	462.1901017144622824 cm/sec2
-   Axial tilt:			145.41254209601916614 degrees
-   Planetary albedo:		0.311497064866191687
+   Equatorial radius:		38749.890109216989803 Km
+   Density:			0.20550188427159997562 grams/cc
+   Escape Velocity:		16.366879684225281236 Km/sec
+   Molecular weight retained:	0.029229227256851212093 and above
+   Surface acceleration:	290.8785984543018058 cm/sec2
+   Axial tilt:			70.990431848679136806 degrees
+   Planetary albedo:		0.31621282879466409177
 
 
 Planet 9
    Distance from primary star:	34.215336130573957396 AU
    Eccentricity of orbit:	0.11288505050073853464
    Length of year:		73101.867977330240585 days
-   Length of day:		24.78802820889064635 hours
+   Length of day:		32.730364301551164167 hours
    Mass:			0.15381154405988455896 Earth masses
-   Surface gravity:		0.34609769173271115225 Earth gees
-   Surface pressure:		3.5418755248773286723e-05 Earth atmospheres
-   Surface temperature:		-228.4708753713865832 degrees Celcius
-   Boiling point of water:	-60.72384207056404648 degrees Celcius
+   Surface gravity:		0.08818488378831397639 Earth gees
+   Surface pressure:		1.2325898472395135449e-05 Earth atmospheres
+   Surface temperature:		-238.17170510516786663 degrees Celcius
+   Boiling point of water:	-69.75389872426026727 degrees Celcius
    Hydrosphere percentage:	0%
-   Cloud cover percentage:	1.4955356426250678019e-09%
-   Ice cover percentage:	0.07850852645417862023%
-   Equatorial radius:		3679.2000613437571268 Km
-   Density:			4.406623018970594791 grams/cc
-   Escape Velocity:		5.774224624712181976 Km/sec
-   Molecular weight retained:	0.028817388740430401826 and above
-   Surface acceleration:	339.40589286305916952 cm/sec2
-   Axial tilt:			65.29397916144770875 degrees
-   Planetary albedo:		0.1504317968969187357
+   Cloud cover percentage:	9.302249903238757955e-10%
+   Ice cover percentage:	100%
+   Equatorial radius:		4858.0531431760298684 Km
+   Density:			1.9141648025077353034 grams/cc
+   Escape Velocity:		5.0250367900281207403 Km/sec
+   Molecular weight retained:	0.10119438214470681256 and above
+   Surface acceleration:	86.479829060266922444 cm/sec2
+   Axial tilt:			77.51865610380134797 degrees
+   Planetary albedo:		0.6999999999983255506
 
 
 Planet 10
    Distance from primary star:	48.215196160164372582 AU
    Eccentricity of orbit:	0.06741210509082971869
    Length of year:		122284.98038136711079 days
-   Length of day:		28.524550989367331327 hours
+   Length of day:		32.43006927791300473 hours
    Mass:			0.22609161332517152814 Earth masses
-   Surface gravity:		0.20646719834364778789 Earth gees
-   Surface pressure:		4.6034820014888717547e-05 Earth atmospheres
-   Surface temperature:		-244.13625141866297123 degrees Celcius
-   Boiling point of water:	-58.355427736617315304 degrees Celcius
+   Surface gravity:		0.064576108636668875875 Earth gees
+   Surface pressure:		2.093288557068047347e-05 Earth atmospheres
+   Surface temperature:		-243.75163788596597551 degrees Celcius
+   Boiling point of water:	-65.32110468115178037 degrees Celcius
    Hydrosphere percentage:	0%
-   Cloud cover percentage:	7.7024114940837204276e-10%
+   Cloud cover percentage:	5.4684621027449534527e-10%
    Ice cover percentage:	100%
-   Equatorial radius:		5133.079605591461483 Km
-   Density:			2.3852155534376272455 grams/cc
-   Escape Velocity:		5.9269209802009444684 Km/sec
-   Molecular weight retained:	0.027547832978247132874 and above
-   Surface acceleration:	202.4751550636733504 cm/sec2
-   Axial tilt:			105.211996063647291066 degrees
-   Planetary albedo:		0.6999999999986135215
+   Equatorial radius:		5835.889486246459325 Km
+   Density:			1.6230819715189874048 grams/cc
+   Escape Velocity:		5.5585895587898162193 Km/sec
+   Molecular weight retained:	0.06602731896490774684 and above
+   Surface acceleration:	63.327529576178880812 cm/sec2
+   Axial tilt:			106.287605298331413906 degrees
+   Planetary albedo:		0.69999999999901563245


### PR DESCRIPTION
## Two related stellar-classification correctness fixes

Both affect stars specified by **mass/luminosity** (the primary `-m` mode — the goldens use `-m1.0`). Catalog/spectral-type-specified stars are unaffected.

### 1. Effective temperature (the impactful one — fixes the habitable zone)
On the `-m` path the Sun's effective temperature was derived from a *defaulted (empty) spectral type*, flooring it at **~273 K ("Y9V")**. The Kopparapu habitable zone uses `t = Teff − 5780`, so 273 K → `t = −5507`, far outside the polynomial's 2600–7200 K validity — **corrupting the HZ and habitability classification for every `-m` run** (e.g. the inner edge landed at ~1.16 AU instead of ~0.75 AU).

Now derived physically from mass + luminosity: **Eker et al. 2018** mass–Teff above 1.5 M☉; **Stefan–Boltzmann** from L and the Eker mass–radius relation at/below 1.5 M☉. Sun → **5778 K** (was 273 K).

### 2. Spectral type
`eff_temp_to_spec_type`'s class boundaries were miscalibrated (G set at 6000 K, so a 5778 K Sun → "K2V"; "O" was unreachable). Corrected to the standard **Morgan-Keenan / Pecaut & Mamajek (2013)** scale.

Result across the mass range:
| M (M☉) | Teff | SpT |
|---|---|---|
| 0.3 | 3522 K | M2V |
| 1.0 | 5778 K | **G3V** (was 273 K Y9V) |
| 2.0 | 8374 K | A6V |
| 8.0 | 21592 K | B4 |

## Verification
`scripts/verify.sh --determinism` → 100% tests passed, 0 failed out of 13; 10× -T8 + -T1/-T2/-T4 byte-identical. Goldens regenerated (Teff / spectral type / HZ / habitability all shift to correct values).

## Known follow-up (out of scope)
The luminosity-class (V/IV/III) logic still labels some main-sequence stars IV/III; the spectral class + subclass are now correct.

Ref: `research/modern/07-stellar-relations-binaries.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)