### PR TITLE
feat(climate): Lehmer 2020 1-D-climate surface-temperature diagnostic

### DIFF
--- a/PlanetRow.h
+++ b/PlanetRow.h
@@ -120,6 +120,7 @@ struct PlanetRow {
   [[=planetrow::fixed_string("PMS Desiccation Risk")]]           bool        pms_desiccation_risk;
   [[=planetrow::fixed_string("High XUV Escape Risk")]]           bool        high_xuv_escape_risk;
   [[=planetrow::fixed_string("CO2 Collapse Risk")]]              bool        co2_collapse_risk;
+  [[=planetrow::fixed_string("Climate Model Surface Temp")]]     long double climate_model_temp;
 
   // --- helper fields: no annotation, skipped by the reflective emitters ---
   std::string atmosphere_json;  // JSON-style atmosphere (toString formatting)

--- a/display.cpp
+++ b/display.cpp
@@ -160,6 +160,11 @@ static void text_print_planet_details(planet* the_planet, int counter) {
               << std::format("   Hydrosphere percentage:\t{}%\n", the_planet->getHydrosphere() * 100.0)
               << std::format("   Cloud cover percentage:\t{}%\n", the_planet->getCloudCover() * 100.0)
               << std::format("   Ice cover percentage:\t{}%\n", the_planet->getIceCover() * 100.0);
+    if (the_planet->getClimateModelTemp() > 0.0) {
+      std::cout << std::format(
+          "   1D-climate surface temp:\t{} degrees Celcius (Lehmer et al. 2020)\n",
+          the_planet->getClimateModelTemp() - FREEZING_POINT_OF_WATER);
+    }
   }
 
   // Physical properties (all planets)
@@ -459,6 +464,7 @@ auto to_row(planet* the_planet, bool is_moon, const std::string& id, bool do_gas
   r.pms_desiccation_risk         = the_planet->getPmsDesiccationRisk();
   r.high_xuv_escape_risk         = the_planet->getHighXuvEscapeRisk();
   r.co2_collapse_risk            = the_planet->getCo2CollapseRisk();
+  r.climate_model_temp           = the_planet->getClimateModelTemp();
   r.atmosphere_json              = atmosphere_json;
   r.is_moon                      = is_moon;
   return r;

--- a/enviro.cpp
+++ b/enviro.cpp
@@ -2915,6 +2915,80 @@ void set_habitability_flags(planet *the_planet) {
       rocky && in_hz && the_planet->getSurfTemp() < FREEZING_POINT_OF_WATER);
 }
 
+/**
+ * @brief Closed-form 1-D-climate surface temperature for an Earth-like CO2-H2O
+ * atmosphere, from Lehmer, Catling & Krissansen-Totton 2020 (Nature Comms 11,
+ * 6153; arXiv:2012.00819, eq. 8). A 4th-order bivariate polynomial in
+ * X = ln(pCO2[bar]) and Y = S/S_earth, fit to the VPL 1-D radiative-convective
+ * model (max error ~3%). Returns the full surface temperature in K (greenhouse
+ * and Bond albedo are implicit). Caller must ensure the validity domain:
+ * S in [0.35, 1.05] S_earth, pCO2 in [1e-6, 10] bar.
+ * See research/modern/10-greenhouse-Ts-polynomial.md.
+ *
+ * @param instellation incident flux S normalized to the solar constant (S/S_earth)
+ * @param pco2_bar CO2 partial pressure in bar
+ * @return surface temperature in Kelvin
+ */
+auto lehmer_surface_temp(long double instellation, long double pco2_bar) -> long double {
+  // c[i][j] multiplies X^i * Y^j (i = power of ln(pCO2), j = power of S/S_earth).
+  static const long double c[5][5] = {
+      {  4.809L, 1045.0L, -1496.0L, 1064.0L, -281.1L},
+      {-222.0L,  1414.0L, -2964.0L, 2655.0L, -868.4L},
+      {-68.44L,   446.4L,  -978.4L,  907.5L, -304.6L},
+      { -6.737L,   44.41L,  -98.86L,   92.87L, -31.48L},
+      { -0.206L,    1.364L,   -3.059L,   2.892L,  -0.985L},
+  };
+  const long double X = std::log(pco2_bar);  // natural log; pCO2 in bar
+  const long double Y = instellation;
+  long double t = 0.0L;
+  long double xi = 1.0L;  // X^i
+  for (const auto& row : c) {
+    long double yj = 1.0L;  // Y^j
+    for (long double cij : row) {
+      t += cij * xi * yj;
+      yj *= Y;
+    }
+    xi *= X;
+  }
+  return t;
+}
+
+/**
+ * @brief Set the diagnostic Lehmer 2020 1-D-climate surface temperature on the
+ * planet, or 0 if it is outside the model's validity domain.
+ *
+ * Additive diagnostic only: does NOT change the planet's actual surface
+ * temperature or any habitability classification. Applies to rocky planets with
+ * an Earth-like CO2-bearing atmosphere whose instellation S = L/a^2 lies in
+ * [0.35, 1.05] S_earth and whose CO2 partial pressure lies in [1e-6, 10] bar.
+ */
+void set_climate_model_temp(planet *the_planet) {
+  the_planet->setClimateModelTemp(0.0);  // sentinel: not applicable
+  if (is_gas_planet(the_planet)) {
+    return;
+  }
+  long double a = the_planet->getA();
+  if (a <= 0.0) {
+    return;
+  }
+  long double instellation = the_planet->getTheSun().getLuminosity() / (a * a);
+  if (instellation < 0.35 || instellation > 1.05) {
+    return;
+  }
+  long double pco2_mb = 0.0;  // CO2 partial pressure, millibars
+  for (int i = 0; i < the_planet->getNumGases(); i++) {
+    if (the_planet->getGas(i).getNum() == AN_CO2) {
+      pco2_mb = the_planet->getGas(i).getSurfPressure();
+      break;
+    }
+  }
+  long double pco2_bar = pco2_mb / MILLIBARS_PER_BAR;
+  if (pco2_bar < 1.0e-6 || pco2_bar > 10.0) {
+    return;
+  }
+  the_planet->setClimateModelTemp(lehmer_surface_temp(instellation, pco2_bar));
+}
+
 auto is_potentialy_habitable_optimistic_size(planet *the_planet) -> bool {
   /*if ((the_planet->getMass() * SUN_MASS_IN_EARTH_MASSES) > 10.0 ||
    (the_planet->getMass() * SUN_MASS_IN_EARTH_MASSES) < 0.1) // The Plantary

--- a/enviro.h
+++ b/enviro.h
@@ -122,6 +122,8 @@ auto is_habitable_earth_like(planet *) -> bool;
 auto is_potentialy_habitable(planet *) -> bool;
 auto is_habitable(planet *) -> bool;
 void set_habitability_flags(planet *);
+auto lehmer_surface_temp(long double instellation, long double pco2_bar) -> long double;
+void set_climate_model_temp(planet *);
 auto convert_km_to_eu(long double) -> long double;
 void makeHabitable(StarGenerator*, sun &, planet *, const std::string&, bool, bool);
 

--- a/research/modern/10-greenhouse-Ts-polynomial.md
+++ b/research/modern/10-greenhouse-Ts-polynomial.md
@@ -1,0 +1,53 @@
+# Closed-form surface-temperature polynomial T_s(S, pCO2)
+
+Source: **Lehmer, Catling & Krissansen-Totton (2020)**, "Carbonate-Silicate Cycle
+Predictions of Earth-like Planetary Climates and Testing the Habitable Zone Concept,"
+Nature Communications 11, 6153 (arXiv:2012.00819), **equation 8** (Methods §4.1).
+
+Fit to the Virtual Planetary Laboratory 1-D radiative-convective climate model for an
+Earth-like CO2-H2O atmosphere (Manabe-Wetherald humidity; if pCO2 < 1 bar the total
+pressure is topped up to 1 bar with N2). Bond albedo is computed dynamically by the 1-D
+model and is therefore *implicit* in the fit. Maximum error vs the 1-D model ~3%.
+
+**Variables:** `X = ln(pCO2)` with pCO2 in **bar**; `Y = S / S_earth` (instellation
+normalized to the solar constant).
+
+**Validity domain:** S in [0.35, 1.05] S_earth; pCO2 in [1e-6, 10] bar.
+
+```
+Ts(S, pCO2) =  4.809
+             − 222.0  X      − 68.44  X^2   − 6.737  X^3   − 0.206  X^4
+             + 1414   X Y    + 446.4  X^2 Y + 44.41  X^3 Y + 1.364  X^4 Y
+             − 2964   X Y^2  − 978.4  X^2 Y^2− 98.86  X^3 Y^2− 3.059  X^4 Y^2
+             + 2655   X Y^3  + 907.5  X^2 Y^3+ 92.87  X^3 Y^3+ 2.892  X^4 Y^3
+             − 868.4  X Y^4  − 304.6  X^2 Y^4− 31.48  X^3 Y^4− 0.985  X^4 Y^4
+             + 1045   Y      − 1496   Y^2   + 1064   Y^3   − 281.1  Y^4
+```
+
+As a 5x5 coefficient matrix `c[i][j]` (term = c[i][j] · X^i · Y^j, i=power of X, j=power of Y):
+
+| i\j | j=0 | j=1 | j=2 | j=3 | j=4 |
+|---|---|---|---|---|---|
+| i=0 | 4.809 | 1045 | −1496 | 1064 | −281.1 |
+| i=1 | −222.0 | 1414 | −2964 | 2655 | −868.4 |
+| i=2 | −68.44 | 446.4 | −978.4 | 907.5 | −304.6 |
+| i=3 | −6.737 | 44.41 | −98.86 | 92.87 | −31.48 |
+| i=4 | −0.206 | 1.364 | −3.059 | 2.892 | −0.985 |
+
+T_s is returned in Kelvin.
+
+## Verification
+Earth check: pCO2 ≈ 280 ppm = 2.8e-4 bar → X = −8.18; Y = 1.0 → T_s ≈ 298 K (Earth's
+mean ~288 K; the idealized 1-bar CO2-H2O model runs a few K warm). Coefficients
+transcribed from the arXiv PDF (pdftotext), not from MathML.
+
+## Integration notes for StarGen
+This polynomial returns the FULL surface temperature (greenhouse included; albedo
+implicit), for a narrow Earth-like regime — it is NOT a drop-in for `green_rise`
+(which returns only a greenhouse increment on top of an effective temperature).
+A safe integration overrides the final surface temperature with this polynomial ONLY
+for rocky planets inside the validity domain (S in [0.35,1.05], pCO2 in [1e-6,10] bar,
+~1 bar Earth-like CO2-H2O atmosphere), falling back to StarGen's existing iterative
+solver everywhere else (Venus-like, thin/thick atmospheres, gas giants, hot/cold
+planets). Requires the CO2 partial pressure and instellation S = (L/Lsun)/(a/AU)^2.
+Keep `grnhouse`/`green_rise` (fallback + unit tests #6/#7).

--- a/stargen.cpp
+++ b/stargen.cpp
@@ -2378,6 +2378,7 @@ void generate_planet(StarGenerator* gen, planet *the_planet, int planet_no, sun 
   the_planet->setEsi(calcEsi(the_planet));
   the_planet->setSph(calcSph(the_planet));
   set_habitability_flags(the_planet);
+  set_climate_model_temp(the_planet);
 
   // Generate moons for this planet (if not a moon itself)
   generate_moons(gen, the_planet, planet_no, the_sun, random_tilt, planet_id,

--- a/structs.cpp
+++ b/structs.cpp
@@ -1279,6 +1279,8 @@ auto planet::getHighXuvEscapeRisk() -> bool { return highXuvEscapeRisk; }
 
 auto planet::getCo2CollapseRisk() -> bool { return co2CollapseRisk; }
 
+auto planet::getClimateModelTemp() -> long double { return climateModelTemp; }
+
 auto planet::getRmf() -> long double { return rmf; }
 
 auto planet::getRmsVelocity() -> long double { return rmsVelocity; }
@@ -1440,6 +1442,8 @@ void planet::setPmsDesiccationRisk(bool b) { pmsDesiccationRisk = b; }
 void planet::setHighXuvEscapeRisk(bool b) { highXuvEscapeRisk = b; }
 
 void planet::setCo2CollapseRisk(bool b) { co2CollapseRisk = b; }
+
+void planet::setClimateModelTemp(long double t) { climateModelTemp = t; }
 
 void planet::setRmf(long double r) { rmf = r; }
 

--- a/structs.h
+++ b/structs.h
@@ -177,6 +177,10 @@ class planet {
   bool co2CollapseRisk{false};     /* HZ world cold enough that outgassed CO2 may
                                       condense out, risking irreversible
                                       glaciation (Turbet et al. 2017) */
+  long double climateModelTemp{0}; /* diagnostic surface temp (K) from the Lehmer
+                                      et al. 2020 1-D-climate polynomial, for
+                                      Earth-like CO2-H2O atmospheres in its
+                                      validity domain; 0 = not applicable */
   void estimateMass();
  public:
   planet();
@@ -230,6 +234,8 @@ class planet {
   auto getHighXuvEscapeRisk() -> bool;
   void setCo2CollapseRisk(bool);
   auto getCo2CollapseRisk() -> bool;
+  void setClimateModelTemp(long double);
+  auto getClimateModelTemp() -> long double;
   void setEscVelocity(long double);
   auto getEscVelocity() -> long double;
   void setSurfAccel(long double);


### PR DESCRIPTION
## Summary

Adds an **additive diagnostic** surface temperature from the closed-form 4th-order polynomial of **Lehmer, Catling & Krissansen-Totton (2020)** (Nature Comms 11, 6153; arXiv:2012.00819, eq. 8), fit to the VPL 1-D radiative-convective climate model (max error ~3%).

- `lehmer_surface_temp(S, pCO2)` evaluates Ts(X=ln(pCO₂[bar]), Y=S/S⊕) — full surface temperature, greenhouse + Bond albedo implicit.
- `set_climate_model_temp()` applies it to rocky planets inside the validity domain (S∈[0.35,1.05] S⊕, pCO₂∈[10⁻⁶,10] bar) and stores 0 otherwise.

**This is a diagnostic only** — chosen over a full solver replacement because the polynomial is a complete climate solution for a narrow Earth-like regime, whereas StarGen's surface temperature comes from a circular iterative solver (`calculate_surface_temp` ↔ `calculate_gases`). It does **not** change the planet's actual surface temperature or any habitability classification.

Surfaced as a new JSON/CSV field `Climate Model Surface Temp` and a text line (printed only when applicable). It needs an atmosphere, so it's computed only in gas mode (`-g`); in the default no-gas mode it's 0 — so the **goldens are unchanged**.

Coefficients fetched from the arXiv PDF and recorded in `research/modern/10-greenhouse-Ts-polynomial.md`.

## Verification
`scripts/verify.sh --determinism` → 100% tests passed, 0 failed out of 13; goldens unchanged; 10× -T8 + -T1/-T2/-T4 byte-identical. Spot-check: cold outer-HZ planet (S=0.61) → 241 K; Earth-like inputs → ~298 K (hand-check vs the published coefficients).

## Follow-up
The full regime-gated *replacement* of the greenhouse solver (so the modern climate drives habitability for Earth-like planets) remains an option for a future, carefully-validated effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added climate model surface temperature calculations for Earth-like planets with CO2-H2O atmospheres, based on Lehmer et al. (2020) research.
  * Planet details now display computed climate model surface temperatures when available.

* **Documentation**
  * Added technical documentation describing the climate polynomial calculation methodology and validity domain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->