### PR TITLE
feat(ui): inline SVG orbit map + habitable-zone scale in all HTML output

### DIFF
--- a/display.cpp
+++ b/display.cpp
@@ -2252,6 +2252,34 @@ void html_describe_system(planet* innermost_planet, bool do_gases, bool do_moons
   int     moons;
   std::string  typeString;
 
+  // Inline SVG "orbit map": the habitability scale (AU distance axis + green
+  // habitable-zone band + planets positioned by distance). Brought into every
+  // HTML page, including GIF mode, rather than only -V/-S SVG output. Reuses the
+  // same SVG drawing helpers; g_sim_context.planets is set for this system by the
+  // output loop before we run.
+  if (!g_sim_context.planets.empty()) {
+    planet* outermost = g_sim_context.planets.back();
+    SVGScaleParams sp = calculate_svg_scale(innermost_planet, outermost);
+    sun svg_sun = innermost_planet->getTheSun();
+    the_file << "\n<table border=3 cellspacing=2 cellpadding=2 align=center bgcolor='" << BGTABLE
+             << "' width='90%'>\n";
+    the_file << "<tr><th bgcolor='" << BGHEADER << "' align=center>"
+             << "<font size='+2' color='" << TXHEADER
+             << "'>Orbit Map &amp; Habitable Zone</font></th></tr>\n";
+    the_file << "<tr><td bgcolor='" << BGSPACE << "'>\n";
+    the_file << "<svg xmlns='http://www.w3.org/2000/svg' version='1.1' width='100%' "
+                "preserveAspectRatio='xMidYMid meet'\n";
+    the_file << "     viewBox='-" << sp.margin << " -" << sp.margin << " "
+             << (sp.max_x + (sp.margin * 2.0)) << " " << (sp.max_y + (sp.margin * 2.0))
+             << "' style='max-height:220px'>\n";
+    svg_draw_axis(the_file, sp);
+    svg_draw_habitable_zone(the_file, svg_sun, sp);
+    svg_draw_axis_labels(the_file, sp);
+    svg_draw_planets(the_file, innermost_planet, sp);
+    the_file << "</g>\n</svg>\n";
+    the_file << "</td></tr></table>\n";
+  }
+
   the_file << "\n<table border=3 cellspacing=2 cellpadding=2 align=center bgcolor='" << BGTABLE
            << "' width='90%'>\n";
   the_file << "<tr><th colspan=7 bgcolor='" << BGHEADER << "' align=center>\n";


### PR DESCRIPTION
The habitable-zone band and AU distance scale lived only in the SVG map (`svg_draw_habitable_zone`), emitted solely for `-V` (embedded `<object>`) or `-S` (standalone `.svg`). Default/GIF and batch (`-n`) HTML pages had no orbit map and no HZ band at all.

`html_describe_system()` now **inlines the SVG orbit map directly into every HTML page** (an "Orbit Map & Habitable Zone" panel): the AU log-distance axis, the green habitable-zone band, and planets positioned by distance. It reuses the existing static `svg_draw_*` helpers and the per-system `g_sim_context.planets` the output loop sets before output, so it's correct in batch too. The markup is self-contained — no external `.svg` file required.

## Result
Every gif/batch HTML page now shows the habitability scale (band + axis + positioned planets) alongside the planet strip — no `-V` needed.

## Verification
GIF-mode batch pages contain a balanced inline `<svg>` with the green HZ band (`#3ddc84`) and center line (`#9fe6b4`). `scripts/verify.sh` → 100% tests passed, 0 failed out of 13 (HTML is separate from the text/JSON paths the goldens and determinism test exercise).

Note: a `-o` run with `-V` will now show both the embedded `<object>` SVG and this inline SVG (rare double); the common GIF/batch path shows exactly one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)