### PR TITLE
feat(ui): place orbit map in the same section/width as the planet strip

### DIFF
--- a/display.cpp
+++ b/display.cpp
@@ -1629,7 +1629,7 @@ static void html_write_system_details(std::fstream& the_file, sun& the_sun) {
 void html_thumbnails(planet* innermost_planet, std::fstream& the_file, const std::string& system_name,
                      const std::string& url_path, const std::string& system_url, const std::string& svg_url,
                      const std::string& file_name, bool details, bool terrestrials, bool int_link,
-                     bool do_moons, int graphic_format, bool do_gases) {
+                     bool do_moons, int graphic_format, bool do_gases, bool orbit_map) {
   if (!the_file) {
     throw std::runtime_error("StarGen: thumbnail output stream is not open");
   }
@@ -1691,6 +1691,34 @@ void html_thumbnails(planet* innermost_planet, std::fstream& the_file, const std
   }
 
   the_file << "</td></tr>\n";
+
+  // Inline SVG "orbit map" row: the habitability scale (AU distance axis + green
+  // habitable-zone band + planets positioned by distance), placed as a row inside
+  // this same border=3 / width=90% table directly beneath the strip so the two
+  // share a section and width and read together as one scale. GIF mode only — in
+  // SVG mode the <object> above already renders the orbit map, so we skip it here
+  // to avoid a duplicate. g_sim_context.planets is set for this system by the
+  // output loop before we run.
+  if (orbit_map && graphic_format != gfSVG && !g_sim_context.planets.empty()) {
+    planet* outermost = g_sim_context.planets.back();
+    SVGScaleParams sp = calculate_svg_scale(innermost_planet, outermost);
+    sun svg_sun = innermost_planet->getTheSun();
+    the_file << "<tr><th colspan=2 bgcolor='" << BGHEADER << "' align=center>"
+             << "<font size='+1' color='" << TXHEADER
+             << "'>Orbit Map &amp; Habitable Zone</font></th></tr>\n";
+    the_file << "<tr><td colspan=2 bgcolor='" << BGSPACE << "'>\n";
+    the_file << "<svg xmlns='http://www.w3.org/2000/svg' version='1.1' width='100%' "
+                "preserveAspectRatio='xMidYMid meet'\n";
+    the_file << "     viewBox='-" << sp.margin << " -" << sp.margin << " "
+             << (sp.max_x + (sp.margin * 2.0)) << " " << (sp.max_y + (sp.margin * 2.0))
+             << "' style='max-height:220px'>\n";
+    svg_draw_axis(the_file, sp);
+    svg_draw_habitable_zone(the_file, svg_sun, sp);
+    svg_draw_axis_labels(the_file, sp);
+    svg_draw_planets(the_file, innermost_planet, sp);
+    the_file << "</g>\n</svg>\n";
+    the_file << "</td></tr>\n";
+  }
 
   // Write terrestrial/habitable planets table
   if (terrestrials && (terrestrials_seen || habitable_jovians_seen || potentialy_habitables_seen)) {
@@ -2252,33 +2280,9 @@ void html_describe_system(planet* innermost_planet, bool do_gases, bool do_moons
   int     moons;
   std::string  typeString;
 
-  // Inline SVG "orbit map": the habitability scale (AU distance axis + green
-  // habitable-zone band + planets positioned by distance). Brought into every
-  // HTML page, including GIF mode, rather than only -V/-S SVG output. Reuses the
-  // same SVG drawing helpers; g_sim_context.planets is set for this system by the
-  // output loop before we run.
-  if (!g_sim_context.planets.empty()) {
-    planet* outermost = g_sim_context.planets.back();
-    SVGScaleParams sp = calculate_svg_scale(innermost_planet, outermost);
-    sun svg_sun = innermost_planet->getTheSun();
-    the_file << "\n<table border=3 cellspacing=2 cellpadding=2 align=center bgcolor='" << BGTABLE
-             << "' width='90%'>\n";
-    the_file << "<tr><th bgcolor='" << BGHEADER << "' align=center>"
-             << "<font size='+2' color='" << TXHEADER
-             << "'>Orbit Map &amp; Habitable Zone</font></th></tr>\n";
-    the_file << "<tr><td bgcolor='" << BGSPACE << "'>\n";
-    the_file << "<svg xmlns='http://www.w3.org/2000/svg' version='1.1' width='100%' "
-                "preserveAspectRatio='xMidYMid meet'\n";
-    the_file << "     viewBox='-" << sp.margin << " -" << sp.margin << " "
-             << (sp.max_x + (sp.margin * 2.0)) << " " << (sp.max_y + (sp.margin * 2.0))
-             << "' style='max-height:220px'>\n";
-    svg_draw_axis(the_file, sp);
-    svg_draw_habitable_zone(the_file, svg_sun, sp);
-    svg_draw_axis_labels(the_file, sp);
-    svg_draw_planets(the_file, innermost_planet, sp);
-    the_file << "</g>\n</svg>\n";
-    the_file << "</td></tr></table>\n";
-  }
+  // Note: the inline SVG "orbit map" (habitability scale) is emitted by
+  // html_thumbnails as a row inside the strip table directly above, so the strip
+  // and the orbit map share one section and width and read together as a scale.
 
   the_file << "\n<table border=3 cellspacing=2 cellpadding=2 align=center bgcolor='" << BGTABLE
            << "' width='90%'>\n";

--- a/display.h
+++ b/display.h
@@ -43,7 +43,7 @@ void html_star_details_helper(std::fstream& the_file, const std::string& header,
                               long double temperature, long double age,
                               long double life, const std::string &spec_type);
 void html_thumbnails(planet *, std::fstream &, const std::string&, const std::string&, const std::string&, const std::string&,
-                     const std::string&, bool, bool, bool, bool, int, bool);
+                     const std::string&, bool, bool, bool, bool, int, bool, bool orbit_map = false);
 void html_thumbnail_totals(std::fstream &);
 void html_describe_planet(planet *, int, int, bool, const std::string&, std::fstream &);
 void html_describe_system(planet *, bool, bool, const std::string&, std::fstream &);

--- a/stargen.cpp
+++ b/stargen.cpp
@@ -454,7 +454,7 @@ static void output_system(planet* planets, int out_format,
         // GIF graphic mode so no SVG <object> wrapper is emitted.
         html_thumbnails(planets, html_file, planets->getTheSun().getName(),
                         url_path, "", "", "", false, false, true, do_moons,
-                        gfGIF, do_gases);
+                        gfGIF, do_gases, true);
         html_describe_system(planets, do_gases, do_moons, url_path, html_file);
         close_html_file(html_file);
       } else {
@@ -1270,7 +1270,7 @@ auto stargen(actions action, const std::string &flag_char, std::string path,
                          ".html", prognam, html_file);
           html_thumbnails(innermost_planet, html_file, system_name, url_path,
                           system_url, svg_url, file_name, true, false, true,
-                          do_moons, graphic_format, do_gases);
+                          do_moons, graphic_format, do_gases, true);
           html_describe_system(innermost_planet, do_gases, do_moons, url_path,
                                html_file);
           close_html_file(html_file);


### PR DESCRIPTION
## Summary
The inline **Orbit Map & Habitable Zone** SVG used to render as its own separate `border=3` table below the planet strip. This moves it into a row *inside the same `border=3` / `width=90%` table as the horizontal planet strip*, directly beneath it — so the strip and the orbit map share one section and one width and read together as a single distance scale.

## Changes
- `html_thumbnails` gains a `bool orbit_map` param (default `false`). The orbit-map row is emitted only when `orbit_map` is set **and** `graphic_format != gfSVG`, so SVG mode (`-V`) keeps its external `<object>` map and no longer double-renders it.
- The inline-SVG block is removed from `html_describe_system`.
- Call sites: the batch `-n` GIF path and the single-page `-o` path pass `true`; the index `Thumbnails` page keeps the default `false` (no per-system map there).

## Verification
Structural checks on generated pages:
- Batch/GIF page: one balanced inline `<svg>` (green HZ band `#3ddc84` + center `#9fe6b4`) nested inside the **same** outer `border=3 width=90%` table as the strip, ordered strip → orbit map → Planetary Overview.
- `-o -V` (SVG mode): no inline map emitted (external `<object>` only) — fixes the earlier double-map behavior.
- `scripts/verify.sh`: 13/13 tests pass.

Note: HTML/SVG output is not golden-tested, so no golden churn. Visual rendering was not checked in this environment — verified structurally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)