### PR TITLE
fix(ui): let the system map fill full page width (drop the height cap)

### DIFF
--- a/display.cpp
+++ b/display.cpp
@@ -846,11 +846,13 @@ static void svg_draw_system_map(std::fstream& output, const SVGScaleParams& para
   const double view_h   = view_bottom - view_top;
 
   // Full-width, single figure. Generous height cap so it is not cramped; because
-  // everything is one SVG, clamping just scales the whole thing uniformly.
+  // everything is one SVG. No height cap: width fills the cell and the height
+  // follows from the viewBox aspect ratio (height:auto), so it spans the full
+  // page width like the old GIF overview and grows as tall as it needs.
   output << "<svg xmlns='http://www.w3.org/2000/svg' version='1.1' width='100%' "
             "preserveAspectRatio='xMidYMid meet'\n";
   output << "     viewBox='-" << params.margin << " " << view_top << " " << view_w << " " << view_h
-         << "' style='width:100%;max-height:380px'>\n";
+         << "' style='display:block;width:100%;height:auto'>\n";
 
   // Scale first, so icons/connectors paint on top of it.
   svg_draw_axis(output, params);


### PR DESCRIPTION
## Summary
The combined system figure still didn't span the page. With `preserveAspectRatio='meet'`, the `max-height:380px` cap meant that whenever the natural height at 100% width exceeded 380px, the SVG shrank to fit the cap — which also pulled its width below 100%, leaving side gutters.

Fix: drop the height cap and size by width — `style='display:block;width:100%;height:auto'`. The SVG now fills the full cell width (the table is already `width=100%`, and the page CSS sets no `max-width` on `body`/tables) and its height follows from the viewBox aspect ratio. So it fills width like the old GIF overview and gets taller, as requested.

## Verification
- Generated page's SVG carries `width:100%;height:auto` with no `max-height`, inside a `width=100%` table.
- `scripts/verify.sh`: 13/13 pass.

Visual rendering not checked in this environment — verified structurally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)