### PR TITLE
feat(physics): scientifically accurate gas-planet equilibrium temperature

### DIFF
--- a/const.h
+++ b/const.h
@@ -23,6 +23,11 @@ constexpr double EARTH_EXOSPHERE_TEMP = 1273.0; /* Units of degrees Kelvin	*/
 constexpr double SUN_MASS_IN_EARTH_MASSES = 332775.64;
 constexpr double ASTEROID_MASS_LIMIT = 0.001; /* Units of Earth Masses	*/
 constexpr double EARTH_EFFECTIVE_TEMP = 250.0; /* Units of degrees Kelvin (was 255) */
+/* Radiative-equilibrium temperature of a zero-albedo body at 1 AU from the Sun,
+ * full heat redistribution (f=1): T0 = (L_sun / (16*pi*sigma*AU^2))^(1/4) = 278.3 K.
+ * Basis for the standard equilibrium temperature T_eq = T0*(1-A)^(1/4)*(L/Lsun)^(1/4)/sqrt(a).
+ * (Cf. Earth: T0*(1-0.3)^(1/4) = 254.8 K, the textbook equilibrium temperature.) */
+constexpr double T_EQ_BASE = 278.3; /* Units of degrees Kelvin */
 constexpr double CLOUD_COVERAGE_FACTOR = 1.839E-8; /* Km2/kg					*/
 constexpr double EARTH_WATER_MASS_PER_AREA = 3.83E15; /* grams per square km*/
 constexpr double EARTH_SURF_PRES_IN_MILLIBARS = 1013.25;
@@ -68,6 +73,12 @@ constexpr double GAS_RETENTION_THRESHOLD = 6.0; /* ratio of esc vel to RMS vel *
 constexpr double ICE_ALBEDO = 0.7;
 constexpr double CLOUD_ALBEDO = 0.52;
 constexpr double GAS_GIANT_ALBEDO = 0.5; /* albedo of a gas giant	*/
+/* Bond albedo for gas dwarfs / sub-Neptunes. Anchored to the real ice giants
+ * (Neptune 0.29, Uranus 0.30) and the standard sub-Neptune modelling assumption
+ * (~0.3; e.g. K2-18b: Benneke et al. 2019); self-consistent atmospheres often give
+ * lower (hazes absorb: Blain et al. 2021; arXiv:2409.03683). Used instead of the
+ * Sudarsky *giant* class albedos (~0.8) for tSubSubGasGiant bodies. */
+constexpr double SUB_NEPTUNE_ALBEDO = 0.30;
 
 // Albedo values for various celestial body classifications
 constexpr double CLASS_I_ALBEDO = 0.57;

--- a/display.cpp
+++ b/display.cpp
@@ -2219,7 +2219,7 @@ static void html_write_physical_properties(planet* the_planet, std::fstream& the
                             the_planet->getSph());
   } else {
     the_file << std::format(R"(
-<tr><th>Estimated Temperature<br><small>reflective cloud-top equilibrium; excludes greenhouse &amp; internal heat</small></th>
+<tr><th>Estimated Temperature<br><small>radiative equilibrium; excludes greenhouse &amp; internal heat</small></th>
 <td>{:.2f}&deg; K</td>
 <td>{:.2f}&deg; C Earth temperature</td></tr>
 )",

--- a/enviro.cpp
+++ b/enviro.cpp
@@ -899,6 +899,19 @@ auto est_temp(long double ecosphere_radius, long double orb_radius,
          pow1_4((1.0 - albedo) / (1.0 - EARTH_ALBEDO)) * EARTH_AVERAGE_KELVIN;
 }
 
+/*--------------------------------------------------------------------------*/
+/* Standard radiative equilibrium temperature (global average, full heat     */
+/* redistribution): T_eq = T_EQ_BASE * (1-A)^(1/4) * (L/Lsun)^(1/4) / sqrt(a)*/
+/* Uses the star's actual luminosity (in solar units) and the orbital radius */
+/* in AU, rather than est_temp's r_ecosphere proxy and Earth-surface (288 K) */
+/* normalization. Earth (L=1, a=1, A=0.3) -> 254.8 K, the true equilibrium   */
+/* temperature (Earth's 288 K mean surface is that plus a ~33 K greenhouse).  */
+/*--------------------------------------------------------------------------*/
+auto equilibrium_temp(long double luminosity, long double orb_radius,
+                      long double albedo) -> long double {
+  return T_EQ_BASE * pow1_4(1.0 - albedo) * pow1_4(luminosity) / sqrt(orb_radius);
+}
+
 /*-------------------------------------------------------------------------*/
 /* Old grnhouse:                                                           */
 /* Note that if the orbital radius of the planet is greater than or equal  */
@@ -2041,11 +2054,11 @@ void gas_giant_temperature_albedo(planet *the_planet, long double parent_mass,
   if (the_planet->getTheSun().getAge() == 0.0) {
     the_planet->setTheSun(the_sun_clone);
   }
-  temp3 = about(GAS_GIANT_ALBEDO, 0.1);
+  temp3 = about(the_planet->getType() == tSubSubGasGiant ? SUB_NEPTUNE_ALBEDO : GAS_GIANT_ALBEDO,
+                0.1);
   the_planet->setAlbedo(temp3);
-  temp1 = est_temp(the_planet->getTheSun().getREcosphere(
-                       the_planet->getMass() * SUN_MASS_IN_EARTH_MASSES),
-                   the_planet->getA(), the_planet->getAlbedo());
+  temp1 = equilibrium_temp(the_planet->getTheSun().getLuminosity(),
+                           the_planet->getA(), the_planet->getAlbedo());
   the_planet->setEstimatedTemp(temp1);
   // temp4 = new_radius = gas_radius(temp1, the_planet->getDustMass(),
   // the_planet->getMass(), the_planet->getTheSun().getAge(), the_planet);
@@ -2058,7 +2071,13 @@ void gas_giant_temperature_albedo(planet *the_planet, long double parent_mass,
     if (loops >= 1000) {
       break;
     }
-    if (temp1 > TEMPERATURE_CARBON_GIANT) {
+    if (the_planet->getType() == tSubSubGasGiant) {
+      // Gas dwarfs / sub-Neptunes are not Sudarsky giants: use a realistic
+      // ice-giant-like Bond albedo (~0.3) regardless of cloud-class temperature,
+      // instead of the giant water-/ammonia-cloud albedos (~0.8) that made them
+      // absurdly cold. See SUB_NEPTUNE_ALBEDO in const.h for references.
+      new_albedo = about(SUB_NEPTUNE_ALBEDO, 0.1);
+    } else if (temp1 > TEMPERATURE_CARBON_GIANT) {
       new_albedo = about(CARBON_GIANT_ALBEDO, 0.1);
     } else if (temp1 > TEMPERATURE_CLASS_V) {
       new_albedo =
@@ -2094,9 +2113,8 @@ void gas_giant_temperature_albedo(planet *the_planet, long double parent_mass,
       new_albedo = about(METHANE_GIANT_ALBEDO, 0.1);
     }
     temp3 = ((new_albedo * 2.0) + temp3) / 3.0;
-    temp2 = est_temp(the_planet->getTheSun().getREcosphere(
-                         the_planet->getMass() * SUN_MASS_IN_EARTH_MASSES),
-                     the_planet->getA(), temp3);
+    temp2 = equilibrium_temp(the_planet->getTheSun().getLuminosity(),
+                             the_planet->getA(), temp3);
     temp1 = (temp2 + (temp1 * 2.0)) / 3.0;
     the_planet->setEstimatedTemp(temp1);
     // new_radius = gas_radius(temp1, the_planet->getDustMass(),

--- a/enviro.h
+++ b/enviro.h
@@ -45,6 +45,8 @@ auto cloud_fraction(long double, long double, long double, long double)
 auto ice_fraction(long double, long double) -> long double;
 auto eff_temp(long double, long double, long double) -> long double;
 auto est_temp(long double, long double, long double) -> long double;
+auto equilibrium_temp(long double luminosity, long double orb_radius, long double albedo)
+    -> long double;
 auto grnhouse(long double, long double) -> bool;
 auto green_rise(long double, long double, long double) -> long double;
 auto planet_albedo(planet *) -> long double;

--- a/stargen.cpp
+++ b/stargen.cpp
@@ -278,11 +278,11 @@ static auto handle_list_catalog_html_action(catalog& cat_arg) -> int {
  * @brief Handle aSizeCheck action - display type sizes and planet temperatures
  */
 static auto handle_size_check_action() -> int {
-  long double tempE = est_temp(1.0, 1.0, EARTH_ALBEDO);
-  long double tempJ = est_temp(1.0, 5.2034, GAS_GIANT_ALBEDO);
-  long double tempS = est_temp(1.0, 9.5371, GAS_GIANT_ALBEDO);
-  long double tempU = est_temp(1.0, 19.1913, GAS_GIANT_ALBEDO);
-  long double tempN = est_temp(1.0, 30.0690, GAS_GIANT_ALBEDO);
+  long double tempE = equilibrium_temp(1.0, 1.0, EARTH_ALBEDO);
+  long double tempJ = equilibrium_temp(1.0, 5.2034, GAS_GIANT_ALBEDO);
+  long double tempS = equilibrium_temp(1.0, 9.5371, GAS_GIANT_ALBEDO);
+  long double tempU = equilibrium_temp(1.0, 19.1913, GAS_GIANT_ALBEDO);
+  long double tempN = equilibrium_temp(1.0, 30.0690, GAS_GIANT_ALBEDO);
 
   std::cout << "Size of float: " << sizeof(float) << "\n";
   std::cout << "Size of doubles: " << sizeof(double) << "\n";

--- a/tests/enviro_test.cpp
+++ b/tests/enviro_test.cpp
@@ -182,3 +182,34 @@ TEST_CASE("eff_temp scales with distance and albedo as expected",
     // A more reflective (higher-albedo) planet absorbs less and is cooler.
     REQUIRE(eff_temp(r_ecosphere, 1.0L, 0.6L) < t_earth);
 }
+
+// ── Radiative equilibrium temperature ───────────────────────────────────────
+// equilibrium_temp(luminosity, orb_radius, albedo) is the standard
+// T_eq = T_EQ_BASE * (1-A)^(1/4) * (L/Lsun)^(1/4) / sqrt(a) — the physically
+// correct equilibrium temperature used for gas planets (no Earth-surface bias).
+TEST_CASE("equilibrium_temp matches the textbook radiative-equilibrium temperature",
+          "[enviro][temperature]") {
+    // Earth: L=1 Lsun, a=1 AU, A=0.3 -> ~255 K. (Earth's 288 K mean surface is
+    // this equilibrium temperature plus the ~33 K greenhouse effect.)
+    const long double t_earth = equilibrium_temp(1.0L, 1.0L, 0.3L);
+    REQUIRE_THAT(static_cast<double>(t_earth),
+                 WithinRel(static_cast<double>(T_EQ_BASE) * std::pow(0.7, 0.25), 1e-9));
+    REQUIRE(t_earth > 250.0L);
+    REQUIRE(t_earth < 260.0L);
+
+    // Farther out is cooler; quadrupling the distance halves it (T ~ 1/sqrt(a)).
+    REQUIRE(equilibrium_temp(1.0L, 2.0L, 0.3L) < t_earth);
+    REQUIRE_THAT(static_cast<double>(equilibrium_temp(1.0L, 4.0L, 0.3L)),
+                 WithinRel(static_cast<double>(t_earth / 2.0L), 1e-9));
+
+    // A more luminous star warms the planet; T ~ L^(1/4): 16x luminosity doubles T.
+    REQUIRE_THAT(static_cast<double>(equilibrium_temp(16.0L, 1.0L, 0.3L)),
+                 WithinRel(static_cast<double>(t_earth * 2.0L), 1e-9));
+
+    // A more reflective (higher-albedo) planet is cooler.
+    REQUIRE(equilibrium_temp(1.0L, 1.0L, 0.6L) < t_earth);
+
+    // A realistic gas-dwarf albedo at a habitable-zone distance sits below
+    // freezing — the honest equilibrium temperature (greenhouse not included).
+    REQUIRE(equilibrium_temp(1.126L, 1.16L, SUB_NEPTUNE_ALBEDO) < FREEZING_POINT_OF_WATER);
+}

--- a/tests/golden/stargen_seed_12345.txt
+++ b/tests/golden/stargen_seed_12345.txt
@@ -238,35 +238,35 @@ Planet 10	*gas giant*
    Length of year:		1254.145286907297711 days
    Length of day:		14.573735191654934667 hours
    Mass:			32.705540882521099498 Earth masses
-   Equatorial radius:		52044.205329933751912 Km
-   Density:			0.3310406829338612272 grams/cc
+   Equatorial radius:		52011.351048147556273 Km
+   Density:			0.33166840987840720228 grams/cc
    Escape Velocity:		28.756720956383538432 Km/sec
    Molecular weight retained:	0.54613249979630363093 and above
    Surface acceleration:	1291.4305234204351112 cm/sec2
    Axial tilt:			112.91101876386278491 degrees
-   Planetary albedo:		0.69195595406948757046
+   Planetary albedo:		0.56153585696043640147
 
 
 Planet 11
    Distance from primary star:	3.0651501624522978849 AU
    Eccentricity of orbit:	0.17813163723997674784
    Length of year:		1960.0836590924733526 days
-   Length of day:		17.262740718132761033 hours
+   Length of day:		18.136655036425911933 hours
    Mass:			0.58856339012300186014 Earth masses
-   Surface gravity:		1.1186641583943153742 Earth gees
-   Surface pressure:		0.40652564143020255175 Earth atmospheres
-   Surface temperature:		-157.75134164843938814 degrees Celcius
-   Boiling point of water:	76.91890355234352228 degrees Celcius
+   Surface gravity:		0.8652150546040086657 Earth gees
+   Surface pressure:		0.3470645542848555629 Earth atmospheres
+   Surface temperature:		-153.72109882473139919 degrees Celcius
+   Boiling point of water:	73.123398210579580336 degrees Celcius
    Hydrosphere percentage:	0%
-   Cloud cover percentage:	0.0014201847854966342392%
-   Ice cover percentage:	100%
-   Equatorial radius:		5011.7722974743930155 Km
-   Density:			6.671084306525173776 grams/cc
-   Escape Velocity:		9.677804998329255032 Km/sec
-   Molecular weight retained:	0.80802717604320322884 and above
-   Surface acceleration:	1097.0347868917612458 cm/sec2
-   Axial tilt:			58.130838431620155404 degrees
-   Planetary albedo:		0.6999974436673860616
+   Cloud cover percentage:	0.0013156821841023611046%
+   Ice cover percentage:	91.97078704289325371%
+   Equatorial radius:		5265.5084999315316 Km
+   Density:			5.752405175210339991 grams/cc
+   Escape Velocity:		9.441747319348321762 Km/sec
+   Molecular weight retained:	0.933829608011673181 and above
+   Surface acceleration:	848.48612152324012664 cm/sec2
+   Axial tilt:			140.50210924932741818 degrees
+   Planetary albedo:		0.65584057863398775135
 
 
 Planet 12	*gas giant*
@@ -275,13 +275,13 @@ Planet 12	*gas giant*
    Length of year:		3382.0823583910567438 days
    Length of day:		28.02296921185798182 hours
    Mass:			1.8251045386066755698 Earth masses
-   Equatorial radius:		27931.176042876345269 Km
-   Density:			0.119508076701885641095 grams/cc
+   Equatorial radius:		29441.755523765660826 Km
+   Density:			0.102040791113843124474 grams/cc
    Escape Velocity:		10.079352927165185101 Km/sec
-   Molecular weight retained:	0.40614298115698721096 and above
-   Surface acceleration:	347.6589267531330363 cm/sec2
-   Axial tilt:			44.719731576225939307 degrees
-   Planetary albedo:		0.56634259253757936674
+   Molecular weight retained:	0.7445954654544765534 and above
+   Surface acceleration:	179.96255508664779685 cm/sec2
+   Axial tilt:			44.94987871101487542 degrees
+   Planetary albedo:		0.32642208380241496195
 
 
 Planet 13	*gas giant*
@@ -290,35 +290,35 @@ Planet 13	*gas giant*
    Length of year:		6365.7777920396335047 days
    Length of day:		8.550397467820385666 hours
    Mass:			652.3035700326716637 Earth masses
-   Equatorial radius:		72018.145001853082626 Km
-   Density:			2.4917309175677473394 grams/cc
+   Equatorial radius:		71881.02440644000729 Km
+   Density:			2.5060178511973841412 grams/cc
    Escape Velocity:		79.33899952501258813 Km/sec
-   Molecular weight retained:	0.5406655844802810366 and above
-   Surface acceleration:	3238.1043336573698312 cm/sec2
-   Axial tilt:			33.078347816457352337 degrees
-   Planetary albedo:		0.49297464843539304976
+   Molecular weight retained:	0.47360093428364990207 and above
+   Surface acceleration:	2050.6128173455721648 cm/sec2
+   Axial tilt:			141.6647167310223665 degrees
+   Planetary albedo:		0.52479047925666923326
 
 
 Planet 14
    Distance from primary star:	13.648180577000076059 AU
    Eccentricity of orbit:	0
    Length of year:		18416.581102034145806 days
-   Length of day:		18.702326805322549185 hours
+   Length of day:		15.1840773091903063815 hours
    Mass:			0.7490587732460501819 Earth masses
-   Surface gravity:		0.67119971765994387934 Earth gees
-   Surface pressure:		0.22496655414545844487 Earth atmospheres
-   Surface temperature:		-218.68170860007346334 degrees Celcius
-   Boiling point of water:	63.127298835559713552 degrees Celcius
+   Surface gravity:		1.4673674028475741863 Earth gees
+   Surface pressure:		0.40985013588192111399 Earth atmospheres
+   Surface temperature:		-210.88476473034737542 degrees Celcius
+   Boiling point of water:	77.1166395927261874 degrees Celcius
    Hydrosphere percentage:	0%
-   Cloud cover percentage:	4.1808836054526072766e-06%
-   Ice cover percentage:	100%
-   Equatorial radius:		6125.9090180713033713 Km
-   Density:			4.649234438509538937 grams/cc
-   Escape Velocity:		9.875261091485113139 Km/sec
-   Molecular weight retained:	0.06162801376665732119 and above
-   Surface acceleration:	658.22207111898884 cm/sec2
-   Axial tilt:			58.175665282195382133 degrees
-   Planetary albedo:		0.6999999924744094658
+   Cloud cover percentage:	5.631623545335910113e-06%
+   Ice cover percentage:	61.399047929135934183%
+   Equatorial radius:		4973.5135601014450115 Km
+   Density:			8.687666763730469237 grams/cc
+   Escape Velocity:		10.95978929371918086 Km/sec
+   Molecular weight retained:	0.050034657917118438343 and above
+   Surface acceleration:	1438.995854113516286 cm/sec2
+   Axial tilt:			152.34010734451845792 degrees
+   Planetary albedo:		0.48769476896028997665
 
 
 Planet 15	*gas giant*
@@ -327,13 +327,13 @@ Planet 15	*gas giant*
    Length of year:		30244.772765580602988 days
    Length of day:		25.08412678938768658 hours
    Mass:			5.61696320492433811 Earth masses
-   Equatorial radius:		46738.751954401357697 Km
-   Density:			0.07849598127752506237 grams/cc
+   Equatorial radius:		45411.53235747935393 Km
+   Density:			0.0855815773213045468 grams/cc
    Escape Velocity:		14.110530227447829675 Km/sec
-   Molecular weight retained:	0.057165478022198691227 and above
-   Surface acceleration:	105.57862493321802302 cm/sec2
-   Axial tilt:			151.67747771466338236 degrees
-   Planetary albedo:		0.29612447769362602247
+   Molecular weight retained:	0.028582739011099345613 and above
+   Surface acceleration:	168.4561115613690927 cm/sec2
+   Axial tilt:			23.913430484934561804 degrees
+   Planetary albedo:		0.28536771547947128606
 
 
 Planet 16	*gas giant*
@@ -342,32 +342,32 @@ Planet 16	*gas giant*
    Length of year:		50517.515723690898902 days
    Length of day:		30.816081388072626283 hours
    Mass:			2.3835069451012859004 Earth masses
-   Equatorial radius:		39458.05948541599176 Km
-   Density:			0.055358769781930621956 grams/cc
+   Equatorial radius:		39368.871159912951907 Km
+   Density:			0.055735860840978984956 grams/cc
    Escape Velocity:		10.275023681876668706 Km/sec
-   Molecular weight retained:	0.02805229703018419299 and above
-   Surface acceleration:	116.848908779696055 cm/sec2
-   Axial tilt:			36.617616843769475565 degrees
-   Planetary albedo:		0.29459421079507890605
+   Molecular weight retained:	0.05610459406036838598 and above
+   Surface acceleration:	64.764749550563395684 cm/sec2
+   Axial tilt:			167.62535212205790458 degrees
+   Planetary albedo:		0.27570219779186663593
 
 
 Planet 17
    Distance from primary star:	44.658659885913400953 AU
    Eccentricity of orbit:	0.15675788795391934483
    Length of year:		109007.2291973598898 days
-   Length of day:		24.553817206351630276 hours
+   Length of day:		18.08348838498803049 hours
    Mass:			0.90120455136914300455 Earth masses
-   Surface gravity:		0.13225627383555945777 Earth gees
-   Surface pressure:		0.052727225047579766904 Earth atmospheres
-   Surface temperature:		-243.14449844593147176 degrees Celcius
-   Boiling point of water:	33.504505816578159738 degrees Celcius
+   Surface gravity:		0.6224547795188113892 Earth gees
+   Surface pressure:		0.13763440825042278167 Earth atmospheres
+   Surface temperature:		-243.14449844067031255 degrees Celcius
+   Boiling point of water:	52.47430570476427647 degrees Celcius
    Hydrosphere percentage:	0%
-   Cloud cover percentage:	1.4556794577617124916e-07%
+   Cloud cover percentage:	2.624612375873626909e-07%
    Ice cover percentage:	100%
-   Equatorial radius:		8821.606118944703709 Km
-   Density:			1.8730853461544708523 grams/cc
-   Escape Velocity:		9.026383208267169539 Km/sec
-   Molecular weight retained:	0.027172923439864086944 and above
-   Surface acceleration:	129.69909878094891084 cm/sec2
-   Axial tilt:			75.62917950546057 degrees
-   Planetary albedo:		0.69999999973797765314
+   Equatorial radius:		6496.969919097047569 Km
+   Density:			4.6888677832877745134 grams/cc
+   Escape Velocity:		10.517975881930636242 Km/sec
+   Molecular weight retained:	0.0050031044183551414502 and above
+   Surface acceleration:	610.4196163568151483 cm/sec2
+   Axial tilt:			101.15109192106368141 degrees
+   Planetary albedo:		0.6999999995275697279

--- a/tests/golden/stargen_seed_42.txt
+++ b/tests/golden/stargen_seed_42.txt
@@ -163,8 +163,8 @@ Planet 7	*gas giant*
    Length of year:		1996.6568977103012942 days
    Length of day:		10.7484833130800768826 hours
    Mass:			159.64472935996509803 Earth masses
-   Equatorial radius:		64561.584852679357386 Km
-   Density:			0.846465407729891103 grams/cc
+   Equatorial radius:		64202.534535790363435 Km
+   Density:			0.86074645717167954257 grams/cc
    Escape Velocity:		49.771727093452131377 Km/sec
    Molecular weight retained:	0.49422987560448737793 and above
    Surface acceleration:	2815.775274690559798 cm/sec2
@@ -200,35 +200,35 @@ Planet 9	*gas giant*
    Length of year:		7345.088531209174801 days
    Length of day:		8.3668487598389815595 hours
    Mass:			752.10120006876090143 Earth masses
-   Equatorial radius:		70451.996942242612185 Km
-   Density:			3.0688349897282718812 grams/cc
+   Equatorial radius:		70295.50527698082407 Km
+   Density:			3.0893761472697856732 grams/cc
    Escape Velocity:		83.11043275904234499 Km/sec
    Molecular weight retained:	0.5156983854782689041 and above
    Surface acceleration:	3133.6651239475841828 cm/sec2
    Axial tilt:			82.327732939078117624 degrees
-   Planetary albedo:		0.5239454482894993764
+   Planetary albedo:		0.50497062426083823473
 
 
 Planet 10
    Distance from primary star:	12.278965818860191272 AU
    Eccentricity of orbit:	0.028901475546966694469
    Length of year:		15715.914350338152215 days
-   Length of day:		18.176281873683297945 hours
+   Length of day:		22.847047012863241274 hours
    Mass:			0.5993139392335517376 Earth masses
-   Surface gravity:		0.84376448008023437495 Earth gees
-   Surface pressure:		0.18467232360643421154 Earth atmospheres
-   Surface temperature:		-215.51005965423896053 degrees Celcius
-   Boiling point of water:	58.76546645823941617 degrees Celcius
+   Surface gravity:		0.23589939026043567408 Earth gees
+   Surface pressure:		0.071249483127109675796 Earth atmospheres
+   Surface temperature:		-215.51005978141521761 degrees Celcius
+   Boiling point of water:	39.21433587779267782 degrees Celcius
    Hydrosphere percentage:	0%
-   Cloud cover percentage:	5.3419436929557035324e-06%
+   Cloud cover percentage:	3.8710161224919341216e-06%
    Ice cover percentage:	100%
-   Equatorial radius:		5325.362505213948469 Km
-   Density:			5.6621846574893351946 grams/cc
-   Escape Velocity:		9.47389379379290971 Km/sec
-   Molecular weight retained:	0.08397256119331428291 and above
-   Surface acceleration:	827.4502938578830126 cm/sec2
-   Axial tilt:			151.94237917546814742 degrees
-   Planetary albedo:		0.6999999903845013083
+   Equatorial radius:		6693.8227204864116353 Km
+   Density:			2.8510769453850036959 grams/cc
+   Escape Velocity:		8.450180713032655185 Km/sec
+   Molecular weight retained:	0.21110203764078228955 and above
+   Surface acceleration:	231.33827554975014174 cm/sec2
+   Axial tilt:			93.926941428999029426 degrees
+   Planetary albedo:		0.69999999303217093507
 
 
 Planet 11	*gas giant*
@@ -237,13 +237,13 @@ Planet 11	*gas giant*
    Length of year:		39193.61160320925956 days
    Length of day:		18.758665672059562434 hours
    Mass:			24.378251021053557814 Earth masses
-   Equatorial radius:		39713.92738264801766 Km
-   Density:			0.55533009626213976 grams/cc
+   Equatorial radius:		36018.373468277918104 Km
+   Density:			0.7444018302178392016 grams/cc
    Escape Velocity:		23.551419968838798813 Km/sec
-   Molecular weight retained:	0.46242199681318435262 and above
-   Surface acceleration:	605.9917709100457482 cm/sec2
-   Axial tilt:			53.253059174045958457 degrees
-   Planetary albedo:		0.31560451065485191767
+   Molecular weight retained:	0.5435201811536462191 and above
+   Surface acceleration:	256.3709007894254575 cm/sec2
+   Axial tilt:			109.923849654547055366 degrees
+   Planetary albedo:		0.31319271316357627242
 
 
 Planet 12	*gas giant*
@@ -252,10 +252,10 @@ Planet 12	*gas giant*
    Length of year:		92525.851263507627564 days
    Length of day:		32.718167866003221207 hours
    Mass:			2.0991265330649087684 Earth masses
-   Equatorial radius:		37778.628376553482784 Km
-   Density:			0.055549127050084658255 grams/cc
+   Equatorial radius:		37547.670054024261542 Km
+   Density:			0.056580504789578513012 grams/cc
    Escape Velocity:		9.660121720654995879 Km/sec
-   Molecular weight retained:	0.014229196596225863998 and above
-   Surface acceleration:	122.5716976388019723 cm/sec2
-   Axial tilt:			96.084951240891584234 degrees
-   Planetary albedo:		0.30883842923279291435
+   Molecular weight retained:	0.007114598298112931999 and above
+   Surface acceleration:	197.32111437875109336 cm/sec2
+   Axial tilt:			82.94710731329111297 degrees
+   Planetary albedo:		0.29538765243334203075

--- a/tests/golden/stargen_seed_7.txt
+++ b/tests/golden/stargen_seed_7.txt
@@ -116,13 +116,13 @@ Planet 5	*gas giant*
    Length of year:		1249.5177934578438476 days
    Length of day:		16.53623395266104701 hours
    Mass:			17.819444607061895997 Earth masses
-   Equatorial radius:		39182.90497467777339 Km
-   Density:			0.42265056060574471584 grams/cc
+   Equatorial radius:		39176.135535919826726 Km
+   Density:			0.42286969412620891253 grams/cc
    Escape Velocity:		23.194277788071483373 Km/sec
    Molecular weight retained:	0.5138732321540121599 and above
    Surface acceleration:	1305.6803104063465291 cm/sec2
    Axial tilt:			57.700010896413225225 degrees
-   Planetary albedo:		0.7250088166052164684
+   Planetary albedo:		0.6080130976588642055
 
 
 Planet 6	*gas giant*
@@ -131,13 +131,13 @@ Planet 6	*gas giant*
    Length of year:		3614.1837382443345015 days
    Length of day:		8.905578879471576206 hours
    Mass:			461.33340899326759296 Earth masses
-   Equatorial radius:		70577.504557065431406 Km
-   Density:			1.8723765300907291438 grams/cc
+   Equatorial radius:		70504.46336743582673 Km
+   Density:			1.8782017927530618877 grams/cc
    Escape Velocity:		71.291883705759057775 Km/sec
-   Molecular weight retained:	0.5110267558555445101 and above
-   Surface acceleration:	2502.0369142456411617 cm/sec2
-   Axial tilt:			82.97144365737486282 degrees
-   Planetary albedo:		0.60093736525680339244
+   Molecular weight retained:	0.47681661191205888757 and above
+   Surface acceleration:	2363.4890455299061098 cm/sec2
+   Axial tilt:			111.81751114973518213 degrees
+   Planetary albedo:		0.62872985639026910467
 
 
 Planet 7	*gas giant*
@@ -146,13 +146,13 @@ Planet 7	*gas giant*
    Length of year:		14413.040235385907002 days
    Length of day:		8.807496229122457044 hours
    Mass:			703.62649732524165946 Earth masses
-   Equatorial radius:		70706.15000457285814 Km
-   Density:			2.8401926113998359443 grams/cc
+   Equatorial radius:		67647.61194979268052 Km
+   Density:			3.2431120510748900996 grams/cc
    Escape Velocity:		79.666684938196316364 Km/sec
-   Molecular weight retained:	0.5064235737581373343 and above
-   Surface acceleration:	2893.2241564142565946 cm/sec2
-   Axial tilt:			90.881445176781056716 degrees
-   Planetary albedo:		0.34630804558298413056
+   Molecular weight retained:	0.47159692297681727363 and above
+   Surface acceleration:	3975.8173691427693695 cm/sec2
+   Axial tilt:			110.83072817495646234 degrees
+   Planetary albedo:		0.29923408174067279522
 
 
 Planet 8	*gas giant*
@@ -161,54 +161,54 @@ Planet 8	*gas giant*
    Length of year:		23561.165375476410265 days
    Length of day:		22.77341251515869049 hours
    Mass:			8.380116491038893308 Earth masses
-   Equatorial radius:		38749.890109216989803 Km
-   Density:			0.20550188427159997562 grams/cc
+   Equatorial radius:		38201.457849534635912 Km
+   Density:			0.21448030744224232923 grams/cc
    Escape Velocity:		16.366879684225281236 Km/sec
-   Molecular weight retained:	0.029229227256851212093 and above
-   Surface acceleration:	290.8785984543018058 cm/sec2
-   Axial tilt:			70.990431848679136806 degrees
-   Planetary albedo:		0.31621282879466409177
+   Molecular weight retained:	0.014614613628425606046 and above
+   Surface acceleration:	387.87832599979035267 cm/sec2
+   Axial tilt:			25.433935205149946768 degrees
+   Planetary albedo:		0.30376503050777559767
 
 
 Planet 9
    Distance from primary star:	34.215336130573957396 AU
    Eccentricity of orbit:	0.11288505050073853464
    Length of year:		73101.867977330240585 days
-   Length of day:		32.730364301551164167 hours
+   Length of day:		33.247230722541781286 hours
    Mass:			0.15381154405988455896 Earth masses
-   Surface gravity:		0.08818488378831397639 Earth gees
-   Surface pressure:		1.2325898472395135449e-05 Earth atmospheres
-   Surface temperature:		-238.17170510516786663 degrees Celcius
-   Boiling point of water:	-69.75389872426026727 degrees Celcius
+   Surface gravity:		0.092014097817524025433 Earth gees
+   Surface pressure:		1.3172499429662473444e-05 Earth atmospheres
+   Surface temperature:		-238.17170510516902482 degrees Celcius
+   Boiling point of water:	-69.208304463287532826 degrees Celcius
    Hydrosphere percentage:	0%
-   Cloud cover percentage:	9.302249903238757955e-10%
+   Cloud cover percentage:	9.0823581910847104866e-10%
    Ice cover percentage:	100%
-   Equatorial radius:		4858.0531431760298684 Km
-   Density:			1.9141648025077353034 grams/cc
-   Escape Velocity:		5.0250367900281207403 Km/sec
-   Molecular weight retained:	0.10119438214470681256 and above
-   Surface acceleration:	86.479829060266922444 cm/sec2
-   Axial tilt:			77.51865610380134797 degrees
-   Planetary albedo:		0.6999999999983255506
+   Equatorial radius:		4934.769812701443786 Km
+   Density:			1.8262717955946214915 grams/cc
+   Escape Velocity:		4.985823803594536148 Km/sec
+   Molecular weight retained:	0.082233926637731477106 and above
+   Surface acceleration:	90.23500523622219505 cm/sec2
+   Axial tilt:			90.995759340822715444 degrees
+   Planetary albedo:		0.6999999999983651311
 
 
 Planet 10
    Distance from primary star:	48.215196160164372582 AU
    Eccentricity of orbit:	0.06741210509082971869
    Length of year:		122284.98038136711079 days
-   Length of day:		32.43006927791300473 hours
+   Length of day:		31.233782304407881392 hours
    Mass:			0.22609161332517152814 Earth masses
-   Surface gravity:		0.064576108636668875875 Earth gees
-   Surface pressure:		2.093288557068047347e-05 Earth atmospheres
-   Surface temperature:		-243.75163788596597551 degrees Celcius
-   Boiling point of water:	-65.32110468115178037 degrees Celcius
+   Surface gravity:		0.09041634320737630553 Earth gees
+   Surface pressure:		2.5356826778202931568e-05 Earth atmospheres
+   Surface temperature:		-243.7516378859622203 degrees Celcius
+   Boiling point of water:	-63.668382548151299716 degrees Celcius
    Hydrosphere percentage:	0%
-   Cloud cover percentage:	5.4684621027449534527e-10%
+   Cloud cover percentage:	6.3208352379239443e-10%
    Ice cover percentage:	100%
-   Equatorial radius:		5835.889486246459325 Km
-   Density:			1.6230819715189874048 grams/cc
-   Escape Velocity:		5.5585895587898162193 Km/sec
-   Molecular weight retained:	0.06602731896490774684 and above
-   Surface acceleration:	63.327529576178880812 cm/sec2
-   Axial tilt:			106.287605298331413906 degrees
-   Planetary albedo:		0.69999999999901563245
+   Equatorial radius:		5620.614011146496916 Km
+   Density:			1.8168134909159929684 grams/cc
+   Escape Velocity:		5.6640392736299720127 Km/sec
+   Molecular weight retained:	0.06359168983018102644 and above
+   Surface acceleration:	88.668143211461681374 cm/sec2
+   Axial tilt:			53.931663648536058986 degrees
+   Planetary albedo:		0.69999999999886220527


### PR DESCRIPTION
## Problem
A Water Gas Dwarf in the habitable zone (`stargen0002.html#5`, 8.75 M⊕, 1.16 AU) reported an Estimated Temperature of **186.73 K (−86 °C)**. Two real inaccuracies in the gas-planet temperature model caused it:

1. **Albedo:** sub-Neptune "gas dwarfs" (`tSubSubGasGiant`) were given a Sudarsky *giant* Bond albedo (~0.83, water-cloud Class II) — higher than Venus and ~3× any real ice giant. Modern literature puts sub-Neptune Bond albedo at **~0.3** (Neptune 0.29, Uranus 0.30; K2-18b assumed 0.3, self-consistent models often lower). Refs: [Benneke et al. 2019](https://iopscience.iop.org/article/10.3847/2041-8213/ab59dc); [Blain et al. 2021](https://www.aanda.org/articles/aa/full_html/2021/02/aa39072-20/aa39072-20.html); [arXiv:2409.03683](https://arxiv.org/pdf/2409.03683).
2. **Normalization:** `est_temp` normalized to `EARTH_AVERAGE_KELVIN` (287.15 K = Earth's greenhouse *surface* temp), inflating the "equilibrium" temperature ~13% by baking in Earth's 33 K greenhouse.

## Changes
- New `equilibrium_temp(L, a, A) = T_EQ_BASE·(1−A)^¼·(L/L☉)^¼/√a` — the textbook radiative-equilibrium temperature, using the star's **actual luminosity**. `T_EQ_BASE = 278.3 K` (zero-albedo, 1 AU, full redistribution); Earth → 254.8 K. New unit test.
- `gas_giant_temperature_albedo()` uses `equilibrium_temp` instead of `est_temp`, and gives gas dwarfs `SUB_NEPTUNE_ALBEDO = 0.30` instead of the Sudarsky class albedo. **Giants keep the Sudarsky model**, now evaluated on the correct equilibrium-temp scale.
- Display annotation → "radiative equilibrium; excludes greenhouse & internal heat".

## Why it's safe
- Planet **type** is mass-based and locked *before* the loop → no feedback loop.
- **Gas-dwarf radius** (`mini_neptune_radius`, < 17 M⊕) is **flux-based, not temp-based** → gas-dwarf radii unchanged.
- **Giant radius** (`gas_radius`) is the **Fortney 2007 table indexed by equilibrium temperature** → a corrected T_eq gives *more* accurate radii. Verified Jovians stay **~0.94–1.01 R_Jup** at 82–147 K.

## Result
Planet #5 → **243 K (−30 °C)** — the honest equilibrium temperature (Earth's own is 255 K; both sub-freezing without greenhouse). With the merged #59 label fix it reads coherently ("Cold", annotated as excluding greenhouse).

## Verification
- `ctest` **14/14** (incl. regenerated goldens + `population_validation` sanity bounds).
- `scripts/verify.sh --determinism` **PASS** (10× `-T8` + `-T1/-T2/-T4` byte-identical).
- `eff_temp`/`grnhouse` unit tests unaffected.

**Golden diff note:** the regenerated goldens contain the intended gas-planet temp/radius/albedo changes **plus deterministic downstream RNG-stream shifts** — the albedo loop draws `about()` and its convergence count moved, reshuffling later bodies' RNG-driven draws in affected systems. Rocky **temperature** physics is unchanged (a far rocky world's surface temp shifted only in the 7th decimal). This is an artifact of sequential shared-RNG generation, not a physics regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)