### PR TITLE
fix(physics): correct open-ocean Bond albedo (0.04 → 0.06)

### DIFF
--- a/const.h
+++ b/const.h
@@ -94,7 +94,12 @@ constexpr double EARTH_ALBEDO = 0.3;
 constexpr double GREENHOUSE_TRIGGER_ALBEDO = 0.20;
 constexpr double ROCKY_ALBEDO = 0.15;
 constexpr double ROCKY_AIRLESS_ALBEDO = 0.07;
-constexpr double WATER_ALBEDO = 0.04;
+/* Bond albedo of open ocean. Earth's seawater reflects ~0.06 of incident
+ * sunlight in the broadband (diffuse ~0.05-0.08, rising at grazing incidence);
+ * the prior 0.04 sat below the observed range and slightly over-cooled water
+ * worlds. (Cf. Earth ocean albedo ~0.06; Pierrehumbert, Principles of Planetary
+ * Climate 2010.) */
+constexpr double WATER_ALBEDO = 0.06;
 
 // Temperature constants for various celestial bodies
 constexpr double TEMPERATURE_NEPTUNE = 48.1;

--- a/tests/golden/stargen_seed_42.txt
+++ b/tests/golden/stargen_seed_42.txt
@@ -98,18 +98,18 @@ Planet 4
    Mass:			0.70275157781690689954 Earth masses
    Surface gravity:		1.431288968348296826 Earth gees
    Surface pressure:		0.6374057465478117838 Earth atmospheres
-   Surface temperature:		10.7266597384680653915 degrees Celcius
+   Surface temperature:		10.079735045779226965 degrees Celcius
    Boiling point of water:	88.18328607380306039 degrees Celcius
    Hydrosphere percentage:	78.73600166173135274%
-   Cloud cover percentage:	43.785100508583591383%
-   Ice cover percentage:	3.141200265705741779%
+   Cloud cover percentage:	42.138122924652794025%
+   Ice cover percentage:	3.1792484788539148435%
    Equatorial radius:		5077.351779182848753 Km
    Density:			7.6606786566112598505 grams/cc
    Escape Velocity:		10.506503222525771707 Km/sec
    Molecular weight retained:	6.0255179629751864645 and above
    Surface acceleration:	1403.6149961452824548 cm/sec2
    Axial tilt:			162.12711989020007763 degrees
-   Planetary albedo:		0.2690151310106037725
+   Planetary albedo:		0.27509672837955726968
 
 
 Planet 5

--- a/tests/golden/stargen_seed_7.txt
+++ b/tests/golden/stargen_seed_7.txt
@@ -96,18 +96,18 @@ Planet 4
    Mass:			1.9170235954703192081 Earth masses
    Surface gravity:		2.370090445359390402 Earth gees
    Surface pressure:		4.8573296165152146245 Earth atmospheres
-   Surface temperature:		11.246606019104955471 degrees Celcius
+   Surface temperature:		10.691674207583670209 degrees Celcius
    Boiling point of water:	149.6075865504276976 degrees Celcius
-   Hydrosphere percentage:	93.41563786008230453%
-   Cloud cover percentage:	55.751282621527859674%
-   Ice cover percentage:	4.0634348175048564727%
+   Hydrosphere percentage:	90.12345679012345679%
+   Cloud cover percentage:	51.959485450122270857%
+   Ice cover percentage:	5.5162072724885829445%
    Equatorial radius:		6594.721236188012762 Km
    Density:			9.537077453588382914 grams/cc
    Escape Velocity:		15.226196087268623523 Km/sec
    Molecular weight retained:	2.1170414191053176576 and above
    Surface acceleration:	2324.2647465983665025 cm/sec2
    Axial tilt:			131.19832162136182774 degrees
-   Planetary albedo:		0.32921386276640351507
+   Planetary albedo:		0.33108234351186480076
 
 
 Planet 5	*gas giant*


### PR DESCRIPTION
## Summary
`WATER_ALBEDO` was 0.04, below the observed broadband Bond albedo of Earth's oceans (~0.06; diffuse ~0.05–0.08, higher at grazing incidence). The low value slightly over-absorbed insolation on water-rich worlds. Set to **0.06**. (Cf. Pierrehumbert, *Principles of Planetary Climate*, 2010.)

## Verification
- Goldens regenerated: only water-bearing rocky planets shift (albedo + dependent surface-temp/cloud/pressure fields); seed 12345 unchanged.
- `ctest` 14/14.

1 of 5 scientific-accuracy fixes in this batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated water surface reflection calculations to improve planetary environment modeling.

* **Tests**
  * Updated test fixtures to reflect revised planetary calculations, including surface temperature and atmospheric parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->