### PR TITLE
feat(physics): drive rocky surface temperature from the Lehmer 2020 climate model

### DIFF
--- a/enviro.cpp
+++ b/enviro.cpp
@@ -2972,26 +2972,25 @@ auto lehmer_surface_temp(long double instellation, long double pco2_bar) -> long
 }
 
 /**
- * @brief Set the diagnostic Lehmer 2020 1-D-climate surface temperature on the
- * planet, or 0 if it is outside the model's validity domain.
+ * @brief Is the Lehmer 2020 1-D-climate polynomial applicable to this planet,
+ * and if so return its inputs? Rocky planets only, with instellation
+ * S = L/a^2 in [0.35, 1.05] S_earth and CO2 partial pressure in [1e-6, 10] bar.
  *
- * Additive diagnostic only: does NOT change the planet's actual surface
- * temperature or any habitability classification. Applies to rocky planets with
- * an Earth-like CO2-bearing atmosphere whose instellation S = L/a^2 lies in
- * [0.35, 1.05] S_earth and whose CO2 partial pressure lies in [1e-6, 10] bar.
+ * Single source of truth for the validity domain, shared by the diagnostic
+ * setter (set_climate_model_temp) and the driver (apply_lehmer_surface_temp).
  */
-void set_climate_model_temp(planet *the_planet) {
-  the_planet->setClimateModelTemp(0.0);  // sentinel: not applicable
+static auto lehmer_applicable(planet *the_planet, long double &s_out,
+                              long double &pco2_bar_out) -> bool {
   if (is_gas_planet(the_planet)) {
-    return;
+    return false;
   }
   long double a = the_planet->getA();
   if (a <= 0.0) {
-    return;
+    return false;
   }
   long double instellation = the_planet->getTheSun().getLuminosity() / (a * a);
   if (instellation < 0.35 || instellation > 1.05) {
-    return;
+    return false;
   }
   long double pco2_mb = 0.0;  // CO2 partial pressure, millibars
   for (int i = 0; i < the_planet->getNumGases(); i++) {
@@ -3002,9 +3001,56 @@ void set_climate_model_temp(planet *the_planet) {
   }
   long double pco2_bar = pco2_mb / MILLIBARS_PER_BAR;
   if (pco2_bar < 1.0e-6 || pco2_bar > 10.0) {
-    return;
+    return false;
   }
-  the_planet->setClimateModelTemp(lehmer_surface_temp(instellation, pco2_bar));
+  s_out = instellation;
+  pco2_bar_out = pco2_bar;
+  return true;
+}
+
+/**
+ * @brief Set the diagnostic Lehmer 2020 1-D-climate surface temperature on the
+ * planet, or 0 if it is outside the model's validity domain. (Diagnostic field
+ * read by the display; the *actual* surf_temp is driven by
+ * apply_lehmer_surface_temp.)
+ */
+void set_climate_model_temp(planet *the_planet) {
+  long double s = NAN;
+  long double pco2_bar = NAN;
+  the_planet->setClimateModelTemp(
+      lehmer_applicable(the_planet, s, pco2_bar) ? lehmer_surface_temp(s, pco2_bar) : 0.0);
+}
+
+/**
+ * @brief Promote the Lehmer 2020 1-D radiative-convective climate polynomial to
+ * DRIVE the surface temperature of rocky planets inside its validity domain,
+ * replacing the hand-tuned Fogg 1985 grey-opacity result with a GCM-anchored,
+ * CO2-aware temperature. Outside the domain (and for gas planets) the Fogg
+ * result computed by iterate_surface_temp is left untouched (the fallback).
+ *
+ * Minimal and safe: it overrides only surf_temp (and the reported greenhouse
+ * rise + min/max temp range), then lets the caller re-run the habitability
+ * classifiers on the new temperature. It deliberately does NOT re-derive the
+ * hydrosphere/cloud/ice fractions: those were already iterated to convergence by
+ * the Fogg energy balance, and re-deriving them here risks re-establishing an
+ * ocean on a planet that boiled off. The fractions therefore remain those of the
+ * Fogg solution while the reported temperature is the (more accurate) Lehmer one.
+ */
+void apply_lehmer_surface_temp(planet *the_planet) {
+  long double s = NAN;
+  long double pco2_bar = NAN;
+  if (!lehmer_applicable(the_planet, s, pco2_bar)) {
+    return;  // out of domain: keep the Fogg surface temperature
+  }
+  long double ts = lehmer_surface_temp(s, pco2_bar);
+  // Greenhouse rise reported relative to the no-greenhouse equilibrium baseline,
+  // matching how iterate_surface_temp defines greenhsRise.
+  long double baseline = est_temp(the_planet->getTheSun().getREcosphere(
+                                      the_planet->getMass() * SUN_MASS_IN_EARTH_MASSES),
+                                  the_planet->getA(), the_planet->getAlbedo());
+  the_planet->setSurfTemp(ts);
+  the_planet->setGreenhsRise(ts - baseline);
+  set_temp_range(the_planet);
 }
 
 auto is_potentialy_habitable_optimistic_size(planet *the_planet) -> bool {

--- a/enviro.h
+++ b/enviro.h
@@ -126,6 +126,7 @@ auto is_habitable(planet *) -> bool;
 void set_habitability_flags(planet *);
 auto lehmer_surface_temp(long double instellation, long double pco2_bar) -> long double;
 void set_climate_model_temp(planet *);
+void apply_lehmer_surface_temp(planet *);
 auto convert_km_to_eu(long double) -> long double;
 void makeHabitable(StarGenerator*, sun &, planet *, const std::string&, bool, bool);
 

--- a/stargen.cpp
+++ b/stargen.cpp
@@ -2382,6 +2382,11 @@ void generate_planet(StarGenerator* gen, planet *the_planet, int planet_no, sun 
                                      is_moon, the_fudged_radius);
   }
 
+  // Override the Fogg surface temperature with the GCM-anchored Lehmer 2020
+  // climate model for in-domain rocky planets (no-op otherwise), BEFORE the
+  // habitability classifiers below so they see the corrected temperature.
+  apply_lehmer_surface_temp(the_planet);
+
   the_planet->setHzc(calcHzc(the_planet));
   the_planet->setHza(calcHza(the_planet));
   the_planet->setEsi(calcEsi(the_planet));

--- a/tests/enviro_test.cpp
+++ b/tests/enviro_test.cpp
@@ -213,3 +213,22 @@ TEST_CASE("equilibrium_temp matches the textbook radiative-equilibrium temperatu
     // freezing — the honest equilibrium temperature (greenhouse not included).
     REQUIRE(equilibrium_temp(1.126L, 1.16L, SUB_NEPTUNE_ALBEDO) < FREEZING_POINT_OF_WATER);
 }
+
+// ── Lehmer 2020 1-D climate polynomial ───────────────────────────────────────
+// lehmer_surface_temp(S, pCO2_bar) returns the full surface temperature (albedo
+// + CO2/H2O greenhouse implicit) for rocky worlds in S in [0.35,1.05] S_earth,
+// pCO2 in [1e-6,10] bar. It now DRIVES surf_temp for in-domain rocky planets.
+TEST_CASE("lehmer_surface_temp is Earth-like and monotone in CO2 and insolation",
+          "[enviro][temperature][climate]") {
+    // Earth-ish: S=1 S_earth, pCO2 ~ 4e-4 bar (~400 ppm) -> temperate, liquid water.
+    const long double t_earth = lehmer_surface_temp(1.0L, 4.0e-4L);
+    REQUIRE(t_earth > 270.0L);
+    REQUIRE(t_earth < 310.0L);
+
+    // More CO2 -> stronger greenhouse -> warmer (within the valid domain).
+    REQUIRE(lehmer_surface_temp(1.0L, 4.0e-3L) > t_earth);
+
+    // More / less insolation -> warmer / cooler.
+    REQUIRE(lehmer_surface_temp(1.05L, 4.0e-4L) > t_earth);
+    REQUIRE(lehmer_surface_temp(0.40L, 4.0e-4L) < t_earth);
+}


### PR DESCRIPTION
## Summary
The Lehmer–Catling–Krissansen-Totton 2020 1-D radiative-convective climate polynomial (`lehmer_surface_temp`, [arXiv:2012.00819](https://arxiv.org/abs/2012.00819) eq. 8) was already coded but only stored as a **display-only diagnostic**. The real `surf_temp` was still the hand-tuned **Fogg 1985** grey-opacity result (`effective_temp + green_rise`, with a `pow(x,0.4)` exponent the source comment says was "tuned … to match Venus", no CO₂ dependence).

This **promotes Lehmer to drive** the surface temperature of rocky planets inside its validity domain (instellation S = L/a² ∈ [0.35, 1.05] S⊕, CO₂ partial pressure ∈ [1e-6, 10] bar). Outside the domain (and for gas planets) the Fogg result is kept as a **bit-identical fallback**.

## Changes
- `lehmer_applicable()` — single source of truth for the validity domain + inputs, shared by the diagnostic setter and the new driver.
- `apply_lehmer_surface_temp()` — overrides `surf_temp` (+ greenhouse rise + temp range) and runs **before** the habitability classifiers in `generate_planet` so they use the corrected temperature.
- **Minimal & safe (per adversarial review):** does *not* re-derive hydrosphere/cloud/ice fractions (keeps the converged Fogg values), so it can't re-establish an ocean on a boiled-off world; the Fogg energy-balance loop is untouched.
- New unit test (Earth-like range + monotonic in CO₂ and insolation).

## Verification
- For in-domain rocky planets, `Surface Temperature` now equals the GCM-anchored Lehmer value (e.g. an HZ super-Earth → **279.80 K**), confirmed via JSON.
- Golden seeds (`-m1.0`) contain no in-domain planet, so the golden text output is **unchanged** (Fogg path bit-identical there) — no golden churn.
- `ctest` 15/15. Pure per-planet arithmetic (no RNG/shared state) → deterministic.

2 of 5 scientific-accuracy fixes in this batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)