### PR TITLE
feat(physics): physical tidal-lock timescale (Gladman 1996)

### DIFF
--- a/const.h
+++ b/const.h
@@ -66,6 +66,17 @@ constexpr double FREEZING_POINT_OF_WATER = 273.15;
 constexpr double EARTH_AVERAGE_CELSIUS = 14.0;
 constexpr double EARTH_AVERAGE_KELVIN = EARTH_AVERAGE_CELSIUS + FREEZING_POINT_OF_WATER;
 constexpr double DAYS_IN_A_YEAR = 365.256;
+constexpr double SECONDS_PER_YEAR = DAYS_IN_A_YEAR * 24.0 * 3600.0;
+/* Tidal quality factor Q and degree-2 tidal Love number k2 of the SPINNING body,
+ * for the Gladman et al. 1996 (Icarus 122, 166) tidal-synchronization timescale
+ * t_sync ~ (4/9)(Q/k2) a^6 w I / (G M_star^2 R_p^5). Named TIDAL_LOVE_K2_* to
+ * avoid the unrelated K2 (planethood timescale) below.
+ *   Rocky:  Earth-like Q~12, k2~0.30 (Goldreich & Soter 1966; Murray & Dermott 1999, Tab. 4.1).
+ *   Gas:    Jupiter-like Q~1e5, k2~0.38 (Lainey et al. 2009; Wahl et al. 2016). */
+constexpr double TIDAL_Q_ROCKY       = 12.0;
+constexpr double TIDAL_Q_GAS         = 1.0E5;
+constexpr double TIDAL_LOVE_K2_ROCKY = 0.30;
+constexpr double TIDAL_LOVE_K2_GAS   = 0.38;
 //		gas_retention_threshold = 5.0;  		/* ratio of esc vel to
 //RMS vel */
 constexpr double GAS_RETENTION_THRESHOLD = 6.0; /* ratio of esc vel to RMS vel */

--- a/enviro.cpp
+++ b/enviro.cpp
@@ -390,6 +390,53 @@ auto period(long double separation, long double small_mass,
  * @param is_moon 
  * @return long double 
  */
+/*--------------------------------------------------------------------------*/
+/* Tidal synchronization ("despinning") timescale, Gladman et al. 1996       */
+/* (Icarus 122, 166, eq. 1) / Peale 1977 / Murray & Dermott 1999. Pure       */
+/* numeric core in CGS, returned in YEARS so it can be compared directly with */
+/* the system age. The moment of inertia is written explicitly,              */
+/* C = moi_factor * M_p * R_p^2, so the net radius dependence is R_p^-3:      */
+/*   t_sync = (4/9)(Q/k2) * a^6 * w * C / (G * M_star^2 * R_p^5)   [seconds]   */
+/* (The 4/9 prefactor is order-unity and convention-dependent; the lock       */
+/* decision spans many orders of magnitude in t_sync so it is insensitive to  */
+/* it. Sanity: Earth/Sun ~13 Gyr -> unlocked; 1 M_earth at 0.1 AU around a    */
+/* 0.3 Msun M dwarf ~1.5e5 yr -> locked.)                                     */
+/*--------------------------------------------------------------------------*/
+auto tidal_sync_time_years(long double a_au, long double m_star_solar, long double r_p_km,
+                           long double m_p_solar, long double spin_rad_s, long double moi_factor,
+                           long double q, long double k2) -> long double {
+  long double a_cm = a_au * CM_PER_AU;
+  long double m_star_g = m_star_solar * SOLAR_MASS_IN_GRAMS;
+  long double r_p_cm = r_p_km * CM_PER_KM;
+  long double m_p_g = m_p_solar * SOLAR_MASS_IN_GRAMS;
+  if (a_cm <= 0.0 || m_star_g <= 0.0 || r_p_cm <= 0.0 || m_p_g <= 0.0 || spin_rad_s <= 0.0 ||
+      k2 <= 0.0) {
+    return INCREDIBLY_LARGE_NUMBER;  // degenerate inputs cannot lock
+  }
+  long double moment_of_inertia = moi_factor * m_p_g * (r_p_cm * r_p_cm);
+  long double a6 = std::pow(a_cm, 6.0L);
+  long double r5 = std::pow(r_p_cm, 5.0L);
+  long double t_sync_sec = (4.0L / 9.0L) * (q / k2) *
+                           (a6 * spin_rad_s * moment_of_inertia) /
+                           (GRAV_CONSTANT * (m_star_g * m_star_g) * r5);
+  return t_sync_sec / SECONDS_PER_YEAR;
+}
+
+/**
+ * @brief Tidal-lock timescale (years) for a planet/moon, selecting Q/k2 by type.
+ * Wrapper over tidal_sync_time_years; pure, no globals/RNG -> determinism-safe.
+ * parent_mass is in SOLAR masses (the star for planets, the planet for moons),
+ * matching day_length's convention.
+ */
+auto tidal_lock_timescale_years(planet *the_planet, long double parent_mass, bool is_moon,
+                                long double spin_rad_s, long double moi_factor) -> long double {
+  long double a_au = is_moon ? the_planet->getMoonA() : the_planet->getA();
+  long double q = is_gas_planet(the_planet) ? TIDAL_Q_GAS : TIDAL_Q_ROCKY;
+  long double k2 = is_gas_planet(the_planet) ? TIDAL_LOVE_K2_GAS : TIDAL_LOVE_K2_ROCKY;
+  return tidal_sync_time_years(a_au, parent_mass, the_planet->getRadius(), the_planet->getMass(),
+                               spin_rad_s, moi_factor, q, k2);
+}
+
 auto day_length(planet *the_planet, long double parent_mass,
                        bool is_moon) -> long double {
   long double planetary_mass_in_grams =
@@ -448,7 +495,14 @@ auto day_length(planet *the_planet, long double parent_mass,
     day_in_hours = RADIANS_PER_ROTATION / (SECONDS_PER_HOUR * ang_velocity);
   }
 
-  if (day_in_hours >= year_in_hours || stopped) {
+  // Physically-derived tidal lock: synchronized when the Gladman et al. 1996
+  // despinning timescale is short compared with the host system age (replaces the
+  // old kinematic day>=year test). NB k2 here is the moment-of-inertia factor
+  // computed at line ~467, NOT a tidal Love number.
+  long double t_sync_years =
+      tidal_lock_timescale_years(the_planet, parent_mass, is_moon, base_angular_velocity, k2);
+
+  if (stopped || (t_sync_years <= the_planet->getTheSun().getAge())) {
     if ((the_planet->getE() > 0.1 && !is_moon) ||
         (the_planet->getMoonE() > 0.1 && is_moon)) {
       if (!is_moon) {

--- a/enviro.h
+++ b/enviro.h
@@ -27,6 +27,11 @@ auto empirical_density(long double, long double, long double, bool)
 auto volume_density(long double, long double) -> long double;
 auto period(long double, long double, long double) -> long double;
 auto day_length(planet *, long double, bool) -> long double;
+auto tidal_sync_time_years(long double a_au, long double m_star_solar, long double r_p_km,
+                           long double m_p_solar, long double spin_rad_s, long double moi_factor,
+                           long double q, long double k2) -> long double;
+auto tidal_lock_timescale_years(planet *, long double, bool, long double, long double)
+    -> long double;
 auto inclination(long double, long double) -> long double;
 auto escape_vel(long double, long double) -> long double;
 auto rms_vel(long double, long double) -> long double;

--- a/tests/enviro_test.cpp
+++ b/tests/enviro_test.cpp
@@ -232,3 +232,29 @@ TEST_CASE("lehmer_surface_temp is Earth-like and monotone in CO2 and insolation"
     REQUIRE(lehmer_surface_temp(1.05L, 4.0e-4L) > t_earth);
     REQUIRE(lehmer_surface_temp(0.40L, 4.0e-4L) < t_earth);
 }
+
+// ── Tidal synchronization timescale (Gladman et al. 1996) ────────────────────
+// tidal_sync_time_years returns the despinning time in years; the generator
+// declares a body tidally locked when this is <= the system age.
+TEST_CASE("tidal_sync_time_years: Earth unlocked, close-in M-dwarf planet locked",
+          "[enviro][tidal]") {
+    const long double earth_mass_solar = 1.0L / SUN_MASS_IN_EARTH_MASSES;
+    const long double earth_spin = 7.29e-5L;  // rad/s (~current Earth)
+
+    // Earth around the Sun: despinning time >> the 4.5 Gyr age -> NOT locked.
+    long double t_earth = tidal_sync_time_years(1.0L, 1.0L, 6378.0L, earth_mass_solar,
+                                                earth_spin, 0.33L, TIDAL_Q_ROCKY, TIDAL_LOVE_K2_ROCKY);
+    REQUIRE(t_earth > 1.0e10L);  // > 10 Gyr
+
+    // Same planet at 0.1 AU around a 0.3 Msun M dwarf: t_sync ~ a^6/M_star^2 plunges
+    // far below any Gyr age -> synchronously rotating (locked).
+    long double t_mdwarf = tidal_sync_time_years(0.1L, 0.3L, 6378.0L, earth_mass_solar,
+                                                 earth_spin, 0.33L, TIDAL_Q_ROCKY, TIDAL_LOVE_K2_ROCKY);
+    REQUIRE(t_mdwarf < 1.0e9L);
+    REQUIRE(t_mdwarf < t_earth);
+
+    // Monotonic in distance: farther out despins far more slowly (t ~ a^6).
+    long double t_far = tidal_sync_time_years(2.0L, 1.0L, 6378.0L, earth_mass_solar,
+                                              earth_spin, 0.33L, TIDAL_Q_ROCKY, TIDAL_LOVE_K2_ROCKY);
+    REQUIRE(t_far > t_earth);
+}


### PR DESCRIPTION
## Summary
`day_length()` declared a planet tidally locked **kinematically** — when its heuristically spun-down day grew to ≥ its year, driven by the Earth-calibrated `CHANGE_IN_EARTH_ANG_VEL`. That has no real dependence on stellar mass or system age, so it mishandled the regime that matters most: close-in **M-dwarf habitable-zone** planets.

This replaces the lock **decision** with the Gladman et al. 1996 (Icarus 122, 166) tidal synchronization timescale vs. the system age:

```
t_sync = (4/9)(Q/k2) · a^6 · ω · I / (G · M_star^2 · R_p^5),   I = moi·M_p·R_p^2
locked  ⇔  t_sync ≤ age
```

## Changes
- Pure numeric core `tidal_sync_time_years()` (CGS → years) + a per-planet wrapper selecting Q/k2 by type. Moment of inertia written explicitly so the net radius dependence is the correct `R_p^-3` (the reviewer caught the draft using `R_p^-5`).
- Constants: `TIDAL_Q_ROCKY=12`, `TIDAL_LOVE_K2_ROCKY=0.30` (Goldreich & Soter 1966; Murray & Dermott 1999); `TIDAL_Q_GAS=1e5`, `TIDAL_LOVE_K2_GAS=0.38` (Lainey 2009; Wahl 2016); `SECONDS_PER_YEAR`.
- `CHANGE_IN_EARTH_ANG_VEL` is kept (still sets the rotation rate of *unlocked* bodies); only the lock decision changes. The high-e spin-orbit-resonance branch (Mercury 3:2) is preserved.
- Pure function of per-planet fields, no RNG/shared state → determinism preserved. New unit test.

## Verification
- Earth → ~13 Gyr (unlocked); 1 M⊕ at 0.1 AU around a 0.3 M☉ M dwarf → ~1.5×10⁵ yr (locked); monotone in distance.
- Empirically: close-in M-dwarf planets now lock (7/11 planets inside 0.3 AU around a 0.3 M☉ star) while **all 78** sampled planets beyond 1 AU stay free.
- `-m1.0` (Sun-like) golden seeds are **byte-identical** (no planet crosses the boundary) → no golden churn.
- `ctest` 16/16; `verify.sh --determinism` PASS (byte-identical); `population_validation` green.

3 of 5 scientific-accuracy fixes in this batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)