### PR TITLE
polish(physics): mass-scaled obliquity tidal reach + document spin-orbit resonance

### DIFF
--- a/const.h
+++ b/const.h
@@ -77,6 +77,12 @@ constexpr double TIDAL_Q_ROCKY       = 12.0;
 constexpr double TIDAL_Q_GAS         = 1.0E5;
 constexpr double TIDAL_LOVE_K2_ROCKY = 0.30;
 constexpr double TIDAL_LOVE_K2_GAS   = 0.38;
+/* Characteristic distance (AU) inside which tides erode a planet's primordial
+ * obliquity, at 1 solar mass. It scales with the stellar mass as M^(1/3) -- the
+ * same dependence as the tidal-locking critical distance (t_sync ~ a^6/M^2 at
+ * fixed age => a_crit ~ M^(1/3)). (Heller et al. 2011, arXiv:1101.2156.) The
+ * value 1.0 keeps the long-standing solar-mass behavior unchanged. */
+constexpr double OBLIQUITY_TIDAL_REACH_AU = 1.0;
 //		gas_retention_threshold = 5.0;  		/* ratio of esc vel to
 //RMS vel */
 constexpr double GAS_RETENTION_THRESHOLD = 6.0; /* ratio of esc vel to RMS vel */

--- a/enviro.cpp
+++ b/enviro.cpp
@@ -588,11 +588,15 @@ auto inclination(long double orb_radius, long double parent_mass) -> long double
   long double obliquity = std::acos(cos_obliquity) * 180.0L / PI;  // degrees, [0,180]
 
   // Tides erode obliquity for planets close to the star (Heller et al. 2011,
-  // arXiv:1101.2156); damp toward zero inside the tidal-influence distance. A
-  // full treatment is the tidal-locking-timescale card; this keeps the prior
-  // close-in damping intent.
-  if (orb_radius < parent_mass) {
-    obliquity *= (orb_radius / parent_mass);
+  // arXiv:1101.2156); damp linearly toward zero inside the tidal-influence
+  // distance. That distance scales with stellar mass as M^(1/3) -- the same
+  // dependence as the tidal-locking critical radius -- rather than the old
+  // dimensionally-inconsistent comparison of an AU distance against a solar mass.
+  // OBLIQUITY_TIDAL_REACH_AU = 1.0 makes this identical to the prior behavior at
+  // one solar mass.
+  long double tidal_reach = OBLIQUITY_TIDAL_REACH_AU * std::cbrt(parent_mass);
+  if (tidal_reach > 0.0 && orb_radius < tidal_reach) {
+    obliquity *= (orb_radius / tidal_reach);
   }
 
   return obliquity;
@@ -1554,6 +1558,19 @@ void set_temp_range(planet *the_planet) {
   the_planet->setMinTemp(soft(wl, max, min));
 }
 
+/**
+ * @brief Spin-orbit resonance ratio for a tidally-evolved eccentric body.
+ *
+ * On an eccentric orbit the tidal equilibrium spin is not 1:1 synchronous but a
+ * higher spin-orbit resonance (e.g. Mercury's 3:2), because the tidal torque is
+ * dominated by the fast pericenter passage. This snaps the body to the nearest
+ * low-order resonance using (1-e)/(1+e) -- the ratio of the orbital angular
+ * velocity at apocenter to that at pericenter -- as the selector, and returns the
+ * resonant ratio = (rotation period)/(orbital period), i.e. the day/year factor
+ * the caller multiplies by the orbital period. Returns 1 (synchronous) at e=0.
+ *   Goldreich & Peale 1966, AJ 71, 425; Murray & Dermott 1999, Solar System
+ *   Dynamics, ch. 5. (Discretized lookup; valid for the low-e terrestrial regime.)
+ */
 auto getSpinResonanceFactor(long double eccentricity) -> long double {
   long double top = 1.0 - eccentricity;
   long double bottom = 1.0 + eccentricity;


### PR DESCRIPTION
## Summary
Two minor correctness/clarity touch-ups in the spin physics.

**Obliquity tidal damping** — the close-in obliquity erosion used `if (orb_radius < parent_mass) obliquity *= orb_radius/parent_mass`, comparing an AU distance directly against a solar mass (dimensionally incoherent; it only "worked" because both are O(1) at 1 M☉). The tidal-influence distance is now `OBLIQUITY_TIDAL_REACH_AU * cbrt(parent_mass)` — the **M^(1/3)** scaling implied by the tidal-locking critical radius (`t_sync ~ a^6/M^2 ⇒ a_crit ~ M^(1/3)`; Heller et al. 2011). With the reach = 1.0 AU at 1 M☉ this is **byte-identical at one solar mass** (golden seeds use `-m1.0`, unchanged) and only corrects the scaling for other stellar masses.

**`getSpinResonanceFactor`** — added a doc comment + citations (Goldreich & Peale 1966; Murray & Dermott 1999) explaining it snaps an eccentric body to the nearest spin-orbit resonance (Mercury-3:2-style) via `(1-e)/(1+e)`. No behavior change.

## Verification
- `ctest` 18/18 incl. the golden regression (`-m1.0` output byte-identical → no golden regen).
- `verify.sh --determinism` PASS (byte-identical).
- M-dwarf (`-m0.3`) systems still produce obliquities (path exercised).

Minor-polish item; closes out the cheap scientific-accuracy work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)