### PR TITLE
fix(viewer): repair the raylib viewer build (Vector3 clash, PI macro, missing include)

### DIFF
--- a/OrbitalSimulator.cpp
+++ b/OrbitalSimulator.cpp
@@ -85,32 +85,32 @@ void OrbitalSimulator::updatePositions() {
 
         double z = (sin_w * sin_i) * x_orb + (cos_w * sin_i) * y_orb;
 
-        state.position = Vector3(x, y, z);
+        state.position = Vec3(x, y, z);
 
         // Calculate velocity (optional, for future use)
         // v = (μ/h) * [-sin(ν), e + cos(ν), 0] in orbital plane
         // Then rotate to 3D space
         // For now, we'll leave velocity as zero - can be added later if needed
-        state.velocity = Vector3(0, 0, 0);
+        state.velocity = Vec3(0, 0, 0);
 
         state.last_update_time = current_time_;
     }
 }
 
-Vector3 OrbitalSimulator::getPosition(planet* p) const {
+Vec3 OrbitalSimulator::getPosition(planet* p) const {
     auto it = states_.find(p);
     if (it != states_.end()) {
         return it->second.position;
     }
-    return Vector3(0, 0, 0);
+    return Vec3(0, 0, 0);
 }
 
-Vector3 OrbitalSimulator::getVelocity(planet* p) const {
+Vec3 OrbitalSimulator::getVelocity(planet* p) const {
     auto it = states_.find(p);
     if (it != states_.end()) {
         return it->second.velocity;
     }
-    return Vector3(0, 0, 0);
+    return Vec3(0, 0, 0);
 }
 
 bool OrbitalSimulator::hasState(planet* p) const {

--- a/OrbitalSimulator.h
+++ b/OrbitalSimulator.h
@@ -14,8 +14,8 @@
  * - OrbitalState = dynamic runtime position (calculated each frame)
  */
 struct OrbitalState {
-    Vector3 position;           // Current 3D position (AU)
-    Vector3 velocity;           // Current 3D velocity (AU/year)
+    Vec3 position;           // Current 3D position (AU)
+    Vec3 velocity;           // Current 3D velocity (AU/year)
     double mean_anomaly;        // Current mean anomaly (radians)
     double last_update_time;    // Last simulation time (years)
 
@@ -46,7 +46,7 @@ struct OrbitalState {
  *
  *   while (running) {
  *       sim.advance(delta_time);                    // ← Calculate positions
- *       Vector3 pos = sim.getPosition(planet);      // ← Get current position
+ *       Vec3 pos = sim.getPosition(planet);      // ← Get current position
  *       renderer.drawPlanet(planet, pos);           // ← Render
  *   }
  *
@@ -93,7 +93,7 @@ public:
      * @param p Planet to query (non-const as planet getters aren't const)
      * @return Position in AU (sun at origin)
      */
-    Vector3 getPosition(planet* p) const;
+    Vec3 getPosition(planet* p) const;
 
     /**
      * @brief Get current 3D velocity of a planet
@@ -101,7 +101,7 @@ public:
      * @param p Planet to query (non-const as planet getters aren't const)
      * @return Velocity in AU/year
      */
-    Vector3 getVelocity(planet* p) const;
+    Vec3 getVelocity(planet* p) const;
 
     /**
      * @brief Get current simulation time

--- a/OrbitalStateManager.cpp
+++ b/OrbitalStateManager.cpp
@@ -137,10 +137,10 @@ void OrbitalStateManager::setTimeScale(double scale) {
  * @param p Planet to query
  * @return Position in AU (sun at origin), or (0,0,0) if not found
  */
-Vector3 OrbitalStateManager::getPosition(const SystemID& system_id, planet* p) const {
+Vec3 OrbitalStateManager::getPosition(const SystemID& system_id, planet* p) const {
     auto it = simulators_.find(system_id);
     if (it == simulators_.end()) {
-        return Vector3(0, 0, 0);
+        return Vec3(0, 0, 0);
     }
 
     return it->second->getPosition(p);
@@ -153,10 +153,10 @@ Vector3 OrbitalStateManager::getPosition(const SystemID& system_id, planet* p) c
  * @param p Planet to query
  * @return Velocity in AU/year, or (0,0,0) if not found
  */
-Vector3 OrbitalStateManager::getVelocity(const SystemID& system_id, planet* p) const {
+Vec3 OrbitalStateManager::getVelocity(const SystemID& system_id, planet* p) const {
     auto it = simulators_.find(system_id);
     if (it == simulators_.end()) {
-        return Vector3(0, 0, 0);
+        return Vec3(0, 0, 0);
     }
 
     return it->second->getVelocity(p);

--- a/OrbitalStateManager.h
+++ b/OrbitalStateManager.h
@@ -34,7 +34,7 @@
  * while (running) {
  *     manager.update(delta_time);  // Update all systems
  *
- *     Vector3 earth_pos = manager.getPosition("Sol", earth_planet);
+ *     Vec3 earth_pos = manager.getPosition("Sol", earth_planet);
  *     // ... render ...
  * }
  * ```
@@ -122,7 +122,7 @@ public:
      * @param p Planet to query
      * @return Position in AU (sun at origin), or (0,0,0) if not found
      */
-    Vector3 getPosition(const SystemID& system_id, planet* p) const;
+    Vec3 getPosition(const SystemID& system_id, planet* p) const;
 
     /**
      * @brief Get 3D velocity of a planet in a system
@@ -131,7 +131,7 @@ public:
      * @param p Planet to query
      * @return Velocity in AU/year, or (0,0,0) if not found
      */
-    Vector3 getVelocity(const SystemID& system_id, planet* p) const;
+    Vec3 getVelocity(const SystemID& system_id, planet* p) const;
 
     /**
      * @brief Get number of systems being managed

--- a/Vector3.h
+++ b/Vector3.h
@@ -9,37 +9,37 @@
  * Used by OrbitalSimulator for position/velocity calculations.
  * Does NOT affect planet generation - purely for runtime simulation.
  */
-struct Vector3 {
+struct Vec3 {
     double x, y, z;
 
-    Vector3() : x(0), y(0), z(0) {}
-    Vector3(double x_, double y_, double z_) : x(x_), y(y_), z(z_) {}
+    Vec3() : x(0), y(0), z(0) {}
+    Vec3(double x_, double y_, double z_) : x(x_), y(y_), z(z_) {}
 
     // Vector operations
-    Vector3 operator+(const Vector3& v) const {
-        return Vector3(x + v.x, y + v.y, z + v.z);
+    Vec3 operator+(const Vec3& v) const {
+        return Vec3(x + v.x, y + v.y, z + v.z);
     }
 
-    Vector3 operator-(const Vector3& v) const {
-        return Vector3(x - v.x, y - v.y, z - v.z);
+    Vec3 operator-(const Vec3& v) const {
+        return Vec3(x - v.x, y - v.y, z - v.z);
     }
 
-    Vector3 operator*(double s) const {
-        return Vector3(x * s, y * s, z * s);
+    Vec3 operator*(double s) const {
+        return Vec3(x * s, y * s, z * s);
     }
 
-    Vector3 operator/(double s) const {
-        return Vector3(x / s, y / s, z / s);
+    Vec3 operator/(double s) const {
+        return Vec3(x / s, y / s, z / s);
     }
 
     // Dot product
-    double dot(const Vector3& v) const {
+    double dot(const Vec3& v) const {
         return x * v.x + y * v.y + z * v.z;
     }
 
     // Cross product
-    Vector3 cross(const Vector3& v) const {
-        return Vector3(
+    Vec3 cross(const Vec3& v) const {
+        return Vec3(
             y * v.z - z * v.y,
             z * v.x - x * v.z,
             x * v.y - y * v.x
@@ -52,12 +52,12 @@ struct Vector3 {
     }
 
     // Normalize
-    Vector3 normalize() const {
+    Vec3 normalize() const {
         double len = length();
         if (len > 0.0) {
             return *this / len;
         }
-        return Vector3(0, 0, 0);
+        return Vec3(0, 0, 0);
     }
 };
 

--- a/orbital_simulator_demo.cpp
+++ b/orbital_simulator_demo.cpp
@@ -132,7 +132,7 @@ int main() {
         int idx = 0;
         for (planet* p = system; p != nullptr; p = p->next_planet) {
             idx++;
-            Vector3 pos = sim.getPosition(p);
+            Vec3 pos = sim.getPosition(p);
             double distance = pos.length();
 
             std::cout << "  Planet " << idx
@@ -156,7 +156,7 @@ int main() {
         }
 
         planet* p = system;  // Just show first planet
-        Vector3 pos = sim.getPosition(p);
+        Vec3 pos = sim.getPosition(p);
 
         std::cout << "Year " << std::setw(2) << year
                  << ": Planet 1 at distance " << pos.length() << " AU\n";

--- a/viewer.cpp
+++ b/viewer.cpp
@@ -16,7 +16,9 @@
 #include <exception>    // for std::exception
 #include <vector>
 #include "raylib.h"
+#undef PI  // raylib defines PI as a float macro; StarGen uses a constexpr double PI (const.h)
 #include "stargen.h"
+#include "const.h"
 #include "StarGenerator.h"
 #include "OrbitalSimulator.h"
 #include "OrbitalStateManager.h"
@@ -128,7 +130,7 @@ std::vector<planet*> buildPlanetList(planet* system) {
 /**
  * @brief Convert world position (AU) to screen position (pixels)
  */
-Vector2 worldToScreen(const Vector3& worldPos, const ViewState& view) {
+Vector2 worldToScreen(const Vec3& worldPos, const ViewState& view) {
     float screenX = SCREEN_WIDTH / 2.0f + (worldPos.x * view.zoom + view.offset.x);
     float screenY = SCREEN_HEIGHT / 2.0f + (worldPos.y * view.zoom + view.offset.y);
     return {screenX, screenY};
@@ -152,7 +154,7 @@ void updateFollowCamera(ViewState& view, const OrbitalStateManager& manager) {
         view.targetOffset = {0, 0};
     } else if (view.followMode == FollowMode::FOLLOW_PLANET && view.followTarget != nullptr) {
         // Follow selected planet
-        Vector3 planetPos = manager.getPosition("main", view.followTarget);
+        Vec3 planetPos = manager.getPosition("main", view.followTarget);
 
         // Calculate offset to center planet
         view.targetOffset.x = -planetPos.x * view.zoom;
@@ -176,7 +178,7 @@ planet* findPlanetAtPosition(Vector2 screenPos, const std::vector<planet*>& plan
     constexpr float CLICK_RADIUS = 10.0f;  // Pixel tolerance
 
     for (planet* p : planets) {
-        Vector3 planetPos = manager.getPosition("main", p);
+        Vec3 planetPos = manager.getPosition("main", p);
         Vector2 screenPlanetPos = worldToScreen(planetPos, view);
 
         float dx = screenPos.x - screenPlanetPos.x;
@@ -195,7 +197,7 @@ planet* findPlanetAtPosition(Vector2 screenPos, const std::vector<planet*>& plan
  * @brief Draw the sun at the center
  */
 void drawSun(const ViewState& view, bool isFollowTarget) {
-    Vector2 sunPos = worldToScreen(Vector3(0, 0, 0), view);
+    Vector2 sunPos = worldToScreen(Vec3(0, 0, 0), view);
     float sunRadius = std::max(5.0f, 10.0f * view.zoom / 50.0f);
 
     DrawCircleV(sunPos, sunRadius, YELLOW);
@@ -210,7 +212,7 @@ void drawSun(const ViewState& view, bool isFollowTarget) {
 /**
  * @brief Draw a planet
  */
-void drawPlanet(planet* p, const Vector3& pos, const ViewState& view, bool isFollowTarget) {
+void drawPlanet(planet* p, const Vec3& pos, const ViewState& view, bool isFollowTarget) {
     Vector2 screenPos = worldToScreen(pos, view);
 
     // Calculate planet visual radius (not to scale, for visibility)
@@ -249,7 +251,7 @@ void drawOrbit(planet* p, const ViewState& view) {
     float a = p->getA();  // Semi-major axis
     float e = p->getE();  // Eccentricity
 
-    Vector2 center = worldToScreen(Vector3(0, 0, 0), view);
+    Vector2 center = worldToScreen(Vec3(0, 0, 0), view);
     float radiusX = a * view.zoom;
     float radiusY = a * (1.0f - e * e) * view.zoom;  // Semi-minor axis approximation
 
@@ -498,7 +500,7 @@ int main() {
             drawOrbit(p, view);
 
             // Get current position
-            Vector3 pos = manager.getPosition("main", p);
+            Vec3 pos = manager.getPosition("main", p);
 
             // Check if this is the follow target
             bool isFollowTarget = (view.followMode == FollowMode::FOLLOW_PLANET &&


### PR DESCRIPTION
## Summary
The real-time raylib viewer (`viewer` target — off by default and in CI) hadn't compiled since raylib was introduced. Three breakages, all fixed:

1. **`Vector3` redefinition** — StarGen's own `struct Vector3` (`Vector3.h`, a double-based orbital vector) collided with raylib's global float `Vector3` wherever both headers met. Renamed the StarGen type `Vector3` → **`Vec3`** across `Vector3.h`, `OrbitalSimulator.{h,cpp}`, `OrbitalStateManager.{h,cpp}`, `orbital_simulator_demo.cpp`, `viewer.cpp` (filename `Vector3.h` and the include guard unchanged). The viewer uses `Vec3` for world positions and raylib's `Vector2` for screen coords; raylib's `Vector3` is unused.
2. **`PI` macro clash** — `raylib.h` does `#define PI 3.14159f`, mangling StarGen's `constexpr double PI`. `#undef PI` right after the raylib include so the `constexpr` PI is used.
3. **`FREEZING_POINT_OF_WATER` undeclared** — `viewer.cpp` didn't include `const.h`. Added it.

## Verification
- `cmake --build build --target viewer` builds **and links**; `./viewer` runs through system generation (seed 42, 6 planets), orbital-sim init, and raylib 5.0 module load (a real window needs a display, unavailable headless).
- The `Vec3` rename touches core orbital files, so confirmed the main build is intact: `scripts/verify.sh` → **ctest 18/18**.
- Viewer stays **OFF in CI** (no display backend), so CI validates the core build with the rename; the viewer build was verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal vector type standardization across orbital simulation and visualization systems to improve code consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->