### PR TITLE
feat(viewer): accretion formation visualization (dust disk → planetesimals → planets)

### DIFF
--- a/AccretionRecorder.h
+++ b/AccretionRecorder.h
@@ -1,0 +1,60 @@
+#ifndef ACCRETION_RECORDER_H
+#define ACCRETION_RECORDER_H
+
+#include <utility>
+#include <vector>
+
+#include "structs.h"  // dust, planet
+
+/**
+ * @brief Passive recorder for the accretion process, used by the viewer's
+ * "formation" visualization. It is OPT-IN: accrete only captures frames when a
+ * recorder pointer is set (default null), so the normal generation path
+ * (stargen, the harness, goldens) is byte-identical and determinism is unchanged.
+ * It only READS state and copies it -- no RNG, no mutation of the accretion.
+ */
+struct AccretionBand {
+    double inner;   // AU
+    double outer;   // AU
+    bool hasDust;
+    bool hasGas;
+};
+
+struct AccretionBody {
+    double a;     // semi-major axis, AU
+    double e;     // eccentricity
+    double mass;  // solar masses
+};
+
+struct AccretionFrame {
+    std::vector<AccretionBand> bands;
+    std::vector<AccretionBody> bodies;
+};
+
+class AccretionRecorder {
+public:
+    std::vector<AccretionFrame> frames;
+
+    /** Append a snapshot of the current dust lanes and planetesimal list. */
+    void capture(const std::vector<dust>& dust_bands, planet* head) {
+        AccretionFrame f;
+        f.bands.reserve(dust_bands.size());
+        for (const auto& b : dust_bands) {
+            // peekInnerEdge() (not getInnerEdge()) -- the latter mutates the band
+            // when inner>=outer, which would perturb the deterministic accretion.
+            double inner = static_cast<double>(b.peekInnerEdge());
+            double outer = static_cast<double>(b.getOuterEdge());
+            if (inner >= outer) {
+                continue;  // degenerate/empty band; nothing to draw
+            }
+            f.bands.push_back({inner, outer, b.getDustPresent(), b.getGasPresent()});
+        }
+        for (planet* p = head; p != nullptr; p = p->next_planet) {
+            f.bodies.push_back({static_cast<double>(p->getA()), static_cast<double>(p->getE()),
+                                static_cast<double>(p->getMass())});
+        }
+        frames.push_back(std::move(f));
+    }
+};
+
+#endif  // ACCRETION_RECORDER_H

--- a/accrete.cpp
+++ b/accrete.cpp
@@ -1,4 +1,5 @@
 #include "accrete.h"
+#include "AccretionRecorder.h"
 #include <cassert>    // for assert
 #include <cmath>      // for pow, sqrt, NAN, fabs, exp, M_PI
 #include <iostream>   // for operator<<, basic_ostream, char_traits, cerr
@@ -784,6 +785,7 @@ auto accrete::dist_planetary_masses(sun &the_sun, long double inner_dust,
   }
 
   set_initial_conditions(inner_dust, outer_dust);
+  if (recorder != nullptr) { recorder->capture(dust_bands, planet_head); }  // initial dust disk
 
   if (the_sun.getIsCircumbinary()) {
     planet_outer_bound = farthest_planet(stell_mass_ratio);
@@ -974,6 +976,9 @@ auto accrete::dist_planetary_masses(sun &the_sun, long double inner_dust,
                         planet_inner_bound, planet_outer_bound);
     }
     // std::cout << "test 3\n";
+    if (recorder != nullptr) {  // one frame per accretion step (formation viewer)
+      recorder->capture(dust_bands, planet_head);
+    }
   }
   ZoneScoped;
 

--- a/accrete.h
+++ b/accrete.h
@@ -8,6 +8,7 @@ class gen;
 class planet;
 class sun;
 class RandomContext;
+class AccretionRecorder;
 
 class accrete {
 
@@ -18,6 +19,9 @@ class accrete {
         void free_generations();
         void reset(); // Reset state for object pool reuse
         void setRandomContext(RandomContext* ctx) { random_ctx = ctx; }
+        // Opt-in accretion-process recorder (viewer "formation" mode). Null by
+        // default -> the normal generation path records nothing and is unchanged.
+        void setAccretionRecorder(AccretionRecorder* r) { recorder = r; }
         auto stellar_dust_limit(long double) -> long double;
         auto dist_planetary_masses(sun &, long double, long double, long double,
                             long double, long double, long double, planet *,
@@ -25,6 +29,7 @@ class accrete {
 
     private:
         RandomContext* random_ctx = nullptr;  // Random context for this accrete instance
+        AccretionRecorder* recorder = nullptr;  // Optional formation-process recorder (default off)
 
     /* Now for some variables global to the accretion process:	    */
     bool dust_left;

--- a/structs.h
+++ b/structs.h
@@ -379,6 +379,11 @@ class dust {
   ~dust();
   void setInnerEdge(long double);
   auto getInnerEdge() const -> long double;
+  // Side-effect-free read of the raw inner edge. getInnerEdge() above mutates
+  // innerEdge (via const_cast) when inner>=outer, which the accretion relies on;
+  // read-only consumers (e.g. the formation recorder) must use this instead so
+  // they never perturb the deterministic accretion state.
+  auto peekInnerEdge() const -> long double { return innerEdge; }
   void setOuterEdge(long double);
   auto getOuterEdge() const -> long double;
   void setDustPresent(bool);

--- a/viewer.cpp
+++ b/viewer.cpp
@@ -19,6 +19,8 @@
 #undef PI  // raylib defines PI as a float macro; StarGen uses a constexpr double PI (const.h)
 #include "stargen.h"
 #include "const.h"
+#include "AccretionRecorder.h"
+#include <algorithm>
 #include "StarGenerator.h"
 #include "OrbitalSimulator.h"
 #include "OrbitalStateManager.h"
@@ -316,6 +318,76 @@ void drawUI(const OrbitalStateManager& manager, const ViewState& view,
     DrawText("ESC: Exit", padding, y, 16, WHITE);
 }
 
+/**
+ * @brief Play back the recorded accretion ("formation") timeline: dust lanes
+ * thinning into rings while planetesimals appear, grow, and merge, scrubbed over
+ * a fixed duration. Returns when the user skips (SPACE/ENTER) or closes the
+ * window; the caller then enters the live orbital view.
+ */
+void playFormation(const AccretionRecorder& rec, ViewState& view) {
+    const int n = static_cast<int>(rec.frames.size());
+    if (n == 0) {
+        return;
+    }
+    const float duration = 12.0f;  // seconds to scrub the whole formation
+
+    // Auto-fit zoom to the initial dust disk / widest orbit.
+    double maxR = 1.0;
+    for (const auto& b : rec.frames.front().bands) maxR = std::max(maxR, b.outer);
+    for (const auto& f : rec.frames)
+        for (const auto& bd : f.bodies) maxR = std::max(maxR, bd.a * (1.0 + bd.e));
+    view.zoom = static_cast<float>((SCREEN_HEIGHT * 0.42) / std::max(1.0, maxR));
+
+    float elapsed = 0.0f;
+    while (!WindowShouldClose()) {
+        elapsed += GetFrameTime();
+        if (IsKeyPressed(KEY_SPACE) || IsKeyPressed(KEY_ENTER)) break;  // skip to orbits
+        if (IsKeyPressed(KEY_R)) elapsed = 0.0f;                        // replay
+        float wheel = GetMouseWheelMove();
+        if (wheel != 0.0f) view.zoom *= (wheel > 0 ? 1.1f : 0.9f);
+
+        float t = std::min(1.0f, elapsed / duration);
+        int idx = static_cast<int>(t * (n - 1));
+        const AccretionFrame& f = rec.frames[idx];
+        Vector2 c = {SCREEN_WIDTH / 2.0f + view.offset.x, SCREEN_HEIGHT / 2.0f + view.offset.y};
+
+        BeginDrawing();
+        ClearBackground(BLACK);
+
+        // Dust lanes: tan where dust remains, faint blue where only gas remains.
+        for (const auto& b : f.bands) {
+            if (!b.hasDust && !b.hasGas) continue;
+            float ri = static_cast<float>(b.inner * view.zoom);
+            float ro = static_cast<float>(b.outer * view.zoom);
+            Color col = b.hasDust ? Color{150, 110, 70, 60} : Color{80, 110, 180, 32};
+            DrawRing(c, ri, ro, 0.0f, 360.0f, 96, col);
+        }
+        // Star.
+        DrawCircleV(c, 6.0f, Color{255, 220, 120, 255});
+        // Planetesimals / embryos: position on their orbit (slow drift), size ~ mass^(1/3).
+        for (const auto& bd : f.bodies) {
+            double theta = std::fmod(bd.a * 2.3999632 + elapsed * 0.3, 2.0 * PI);
+            float x = c.x + static_cast<float>(bd.a * std::cos(theta) * view.zoom);
+            float y = c.y + static_cast<float>(bd.a * std::sin(theta) * view.zoom);
+            double me = bd.mass * SUN_MASS_IN_EARTH_MASSES;
+            float r = static_cast<float>(std::clamp(1.5 + std::cbrt(std::max(me, 1.0e-6)) * 1.6, 1.5, 22.0));
+            Color col = me > 10.0 ? Color{120, 170, 230, 255} : Color{210, 180, 140, 255};
+            DrawCircle(static_cast<int>(x), static_cast<int>(y), r, col);
+        }
+
+        // HUD.
+        DrawText("ACCRETION / FORMATION", 20, 20, 24, YELLOW);
+        DrawText(TextFormat("step %d / %d    bodies: %d", idx + 1, n, (int)f.bodies.size()), 20, 50, 18,
+                 WHITE);
+        DrawText("SPACE/ENTER: skip to orbital view    R: replay    mouse wheel: zoom", 20,
+                 SCREEN_HEIGHT - 30, 16, GRAY);
+        if (t >= 1.0f) {
+            DrawText("formation complete -- SPACE for the live orbital view", 20, 80, 18, GREEN);
+        }
+        EndDrawing();
+    }
+}
+
 int main() {
     // Initialize generation system. The data loaders throw std::runtime_error on
     // a missing/malformed file; fail gracefully instead of std::terminate().
@@ -332,6 +404,8 @@ int main() {
     StarGenerator gen;
     accrete acc;
     sun the_sun;
+    AccretionRecorder recorder;
+    acc.setAccretionRecorder(&recorder);  // capture the formation timeline during generation
     planet* system = generateSystem(gen, acc, the_sun, 42);
 
     if (!system) {
@@ -366,6 +440,11 @@ int main() {
     std::cout << "Starting viewer...\n";
     InitWindow(SCREEN_WIDTH, SCREEN_HEIGHT, "Stellar System Viewer - Advanced Camera");
     SetTargetFPS(60);
+
+    // Play the recorded accretion/formation timeline first, then fall through to
+    // the live orbital view of the finished system.
+    std::cout << "Recorded " << recorder.frames.size() << " formation frames\n";
+    playFormation(recorder, view);
 
     // Main loop
     while (!WindowShouldClose()) {


### PR DESCRIPTION
## Summary
The viewer only animated the **finished** system's orbits. This adds a **formation playback** that shows the accretion process first: dust lanes thinning into rings while planetesimals appear, grow, and merge — then it falls through to the live orbital view.

## How
- **`AccretionRecorder`** (new, `AccretionRecorder.h`) — an **opt-in, passive** recorder. `accrete` holds an `AccretionRecorder*` (default null) and captures a frame `{dust bands, planetesimal a/e/mass}` after the initial disk and after each accretion step in `dist_planetary_masses`. With no recorder set — the entire normal path (stargen, harness, goldens) — nothing is captured and behavior is **byte-identical**.
- **`viewer.cpp`** — attaches a recorder to its `accrete`, then `playFormation()` scrubs the recorded timeline over ~12 s (translucent dust/gas rings + embryos sized by mass^⅓ on slowly-drifting orbits), then enters the orbital view. Controls: `SPACE`/`ENTER` skip, `R` replay, wheel zoom.

## Subtle bug found & fixed
`dust::getInnerEdge()` is **not pure** — when `inner>=outer` it mutates `innerEdge` via `const_cast` (behavior the accretion relies on). Calling it from the recorder mid-accretion perturbed generation (seed 42: 6 → 5 planets). Added **`dust::peekInnerEdge()`** (a genuinely side-effect-free read) for the recorder; `getInnerEdge()` and the accretion are untouched. With the fix the viewer reproduces the baseline (6 planets), and **125 formation frames** are captured.

## Verification
- `scripts/verify.sh --determinism` **PASS** (10× -T8 + -T1/-T2/-T4 byte-identical, ref unchanged at 294147B) → recorder/peek changes don't affect the core.
- `ctest` 18/18. Viewer builds, runs, plays formation → orbital view.
- Viewer stays **OFF in CI** (no display backend); CI validates the core build with these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added accretion formation visualization displaying an animated timeline of planetary system formation before entering the orbital viewer.
  * Users can now observe how dust bands and planetesimals accumulate during system generation.
  * Added playback controls to skip to orbital view or restart the formation sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->