### PR TITLE
fix(enviro): correct breathability CO2/N2 gate, methane class, NH3/N2 limits

### DIFF
--- a/const.h
+++ b/const.h
@@ -54,10 +54,19 @@ constexpr double MAX_HABITABLE_PRESSURE = 118 * PSI_TO_MILLIBARS;
 // atm:
 constexpr double PPM_PRSSURE = EARTH_SURF_PRES_IN_MILLIBARS / 1000000.;
 // Dole p. 18
-constexpr double MAX_F_IPP = 0.1 * PPM_PRSSURE;
-constexpr double MAX_CL_IPP = 1.0 * PPM_PRSSURE;
-constexpr double MAX_NH3_IPP = 100. * PPM_PRSSURE;
-constexpr double MAX_O3_IPP = 0.1 * PPM_PRSSURE;
+// NOTE: at runtime the breathability classifier reads the per-gas inspired-pp
+// limits from data/elements.yaml (the *_IPP macros below are documentation of
+// the values baked into that file, not read directly by enviro.cpp).
+constexpr double MAX_F_IPP = 0.1 * PPM_PRSSURE;   // NIOSH REL / OSHA PEL 0.1 ppm
+constexpr double MAX_CL_IPP = 1.0 * PPM_PRSSURE;  // OSHA PEL ceiling 1 ppm
+// Ammonia lowered from Dole's 1964 figure of 100 ppm to the modern NIOSH REL
+// (TWA 25 ppm; OSHA PEL 50 ppm; IDLH 300 ppm). 100 ppm is acutely irritating
+// and not indefinitely breathable. (NIOSH Pocket Guide, npgd0028.)
+constexpr double MAX_NH3_IPP = 25. * PPM_PRSSURE;
+constexpr double MAX_O3_IPP = 0.1 * PPM_PRSSURE;  // NIOSH ceiling / OSHA PEL 0.1 ppm
+// Methane's limit is its 5% lower explosive limit (50000 ppm), NOT a toxicity
+// threshold -- it is a simple asphyxiant/flammable gas with no PEL. The
+// breathability classifier treats an excess as UNBREATHABLE, not POISONOUS.
 constexpr double MAX_CH4_IPP = 50000. * PPM_PRSSURE;
 constexpr double EARTH_CONVECTION_FACTOR = 0.43;
 

--- a/data/elements.yaml
+++ b/data/elements.yaml
@@ -108,7 +108,7 @@
   abund_e: 1.99526e-05
   abund_s: 3.13329
   reactivity: 0
-  max_inspired_pp: 3106.391184210526 # MAX_N2_IPP
+  max_inspired_pp: 3106.411184210526 # MAX_N2_IPP (2330 mmHg; was 3106.3912 typo)
   min_inspired_pp: 13.332236842105263 # MIN_N2_IPP
 - atomic_number: 8
   symbol: O # Assuming atomic oxygen for symbol, html_symbol is O2
@@ -1900,7 +1900,7 @@
   abund_e: 0.002
   abund_s: 0.001
   reactivity: 1
-  max_inspired_pp: 0.101325 # MAX_NH3_IPP
+  max_inspired_pp: 0.02533125 # MAX_NH3_IPP (25 ppm, NIOSH REL; was 100 ppm)
   min_inspired_pp: 0.0
 - atomic_number: 901
   symbol: H2O

--- a/enviro.cpp
+++ b/enviro.cpp
@@ -1485,9 +1485,19 @@ auto inspired_partial_pressure(long double surf_pressure,
 /*------------------------------------------------------------------------*/
 
 auto breathability(planet *the_planet) -> unsigned int {
-  bool nitrogen_ok = false;
+  // Breathability gates on OXYGEN only. Any gas above its maximum inspired
+  // partial pressure makes the air POISONOUS (handled in the loop); oxygen must
+  // additionally sit at/above its physiological floor. CO2 and N2 are NOT
+  // required to be present: there is no minimum inhaled CO2 or N2 for
+  // respiration (the body holds alveolar pCO2 ~40 mmHg regardless of ambient
+  // CO2), so a clean, CO2-poor / N2-poor O2 atmosphere is perfectly breathable.
+  // Their only hazard is in EXCESS, which the POISONOUS check already covers.
+  // The previous code ANDed nitrogen_ok && co2_ok into BREATHABLE, which wrongly
+  // demanded a *minimum* CO2 (>=0.05 mmHg) and N2 (>=10 mmHg) and so flagged
+  // otherwise-respirable atmospheres UNBREATHABLE; classic StarGen gated on
+  // oxygen alone.
   bool oxygen_ok = false;
-  bool co2_ok = false;
+  bool methane_excess = false;
 
   if (the_planet->getNumGases() == 0) {
     return NONE;
@@ -1506,26 +1516,30 @@ auto breathability(planet *the_planet) -> unsigned int {
     }
 
     if (ipp > gases[gas_no].getMaxIpp()) {
+      // Methane's limit is its 5% lower explosive limit, not a toxicity
+      // threshold -- it is a simple asphyxiant/flammable gas with no PEL. Excess
+      // methane is UNBREATHABLE, not POISONOUS. Defer the verdict so a genuinely
+      // toxic gas over its own limit still takes POISONOUS precedence.
+      if (the_planet->getGas(i).getNum() == AN_CH4) {
+        methane_excess = true;
+        continue;
+      }
       return POISONOUS;
     }
 
-    if (the_planet->getGas(i).getNum() == AN_N) {
-      nitrogen_ok =
-          ipp >= gases[gas_no].getMinIpp() && ipp <= gases[gas_no].getMaxIpp();
-    } else if (the_planet->getGas(i).getNum() == AN_O) {
+    if (the_planet->getGas(i).getNum() == AN_O) {
       oxygen_ok =
-          ipp >= gases[gas_no].getMinIpp() && ipp <= gases[gas_no].getMaxIpp();
-    } else if (the_planet->getGas(i).getNum() == AN_CO2) {
-      co2_ok =
           ipp >= gases[gas_no].getMinIpp() && ipp <= gases[gas_no].getMaxIpp();
     }
   }
 
-  if (nitrogen_ok && oxygen_ok && co2_ok) {
-    return BREATHABLE;
-  } else {
+  if (methane_excess) {
     return UNBREATHABLE;
   }
+  if (oxygen_ok) {
+    return BREATHABLE;
+  }
+  return UNBREATHABLE;
 }
 
 void set_temp_range(planet *the_planet) {


### PR DESCRIPTION
## What

Fixes the genuine defects found in the partial-pressure / breathability audit.

### 1. CO₂/N₂ minimum-gate bug (the main fix)
`breathability()` ANDed `co2_ok && nitrogen_ok` into the BREATHABLE verdict, which required a **minimum** inhaled CO₂ (≥0.05 mmHg) and N₂ (≥10 mmHg). That's backwards physiology — no minimum inhaled CO₂/N₂ is needed to breathe (the body holds alveolar pCO₂ ≈40 mmHg regardless of ambient), and *excess* of either is already caught by the `ipp > maxIpp → POISONOUS` check. The bug marked otherwise-respirable, CO₂-poor / N₂-poor O₂ atmospheres **UNBREATHABLE**. Now gates on oxygen alone, matching classic StarGen.

**Demonstrated** (old-vs-new binary, data held constant): seed 146 `-m1.0 -g` has an N₂/He/O₂/H₂ atmosphere with **no CO₂** → old `unbreathable`, new `breathable`. 1 planet flips across 200 seeds — the case is real but rare at m=1.0.

### 2. Methane reclassification
Excess methane was `POISONOUS`; its limit is the **5% lower explosive limit**, not a toxicity threshold (methane is a simple asphyxiant/flammable gas with no PEL). Reclassified to `UNBREATHABLE`, deferred so a genuinely toxic gas over its own limit still takes POISONOUS precedence.

### 3. Ammonia limit modernized
`MAX_NH3_IPP` 100 ppm (Dole 1964) → **25 ppm** (NIOSH REL TWA; OSHA PEL 50; IDLH 300). 100 ppm is acutely irritating and not indefinitely breathable. Now flags ammonia poisonous at lower abundances (e.g. seeds 30, 49).

### 4. N₂ data-entry slip
`data/elements.yaml` N₂ max inspired pp was `3106.391184210526` mb; the documented 2330 mmHg is `3106.411184210526` mb (−0.00064% off). Feeds the gas-clamp loop, so it produces sub-0.001% gas-pressure shifts.

(The runtime limits live in `data/elements.yaml`; the const.h `*_IPP` macros are documentation — now noted in const.h. The O₂/CO₂-max windows were left as-is: permissive-by-design, a judgment call about what "breathable" means, not a defect.)

## Verification
- `scripts/verify.sh` PASS — build + ctest **18/18** (incl. parallel-determinism case).
- Text goldens **unchanged** (they run without `-g`, so the breathability and gas-clamp paths aren't exercised).
- Population harness architecture metrics in-bounds (changes affect breathability display + gas partial pressures, not masses/orbits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Updates**
  * Ammonia safety threshold updated to 25 ppm, aligning with modern occupational exposure standards
  * Refined gas breathability classification logic for improved accuracy in multi-gas environments
  * Corrected nitrogen threshold values in system data

<!-- end of auto-generated comment: release notes by coderabbit.ai -->