### PR TITLE
feat(units): finish exact length conversions through au (display/structs/enviro)

### DIFF
--- a/display.cpp
+++ b/display.cpp
@@ -12,6 +12,7 @@
 #include "PerformanceMonitor.h"
 #include "SimulationContext.h"
 #include "const.h"
+#include "units.hh"   // au-backed exact length conversions (sgu::)
 #include "elements.h"
 #include "enviro.h"
 #include "stargen.h"
@@ -171,7 +172,7 @@ static void text_print_planet_details(planet* the_planet, int counter) {
   std::cout << std::format("   Equatorial radius:\t\t{} Km\n", the_planet->getRadius())
             << std::format("   Density:\t\t\t{} grams/cc\n", the_planet->getDensity())
             << std::format("   Escape Velocity:\t\t{} Km/sec\n",
-                           the_planet->getEscVelocity() / CM_PER_KM)
+                           sgu::cm_to_km(the_planet->getEscVelocity()))
             << std::format("   Molecular weight retained:\t{} and above\n",
                            the_planet->getMolecWeight())
             << std::format("   Surface acceleration:\t{} cm/sec2\n", the_planet->getSurfAccel())
@@ -2278,7 +2279,7 @@ static void html_write_physical_properties(planet* the_planet, std::fstream& the
                           convert_km_to_eu(the_planet->getPolarRadius()),
                           the_planet->getPolarRadius() / KM_JUPITER_RADIUS,
                           the_planet->getDensity(), the_planet->getDensity() / EARTH_DENSITY,
-                          the_planet->getEscVelocity() / CM_PER_KM, the_planet->getMolecWeight());
+                          sgu::cm_to_km(the_planet->getEscVelocity()), the_planet->getMolecWeight());
 
   list_molecules(the_file, the_planet->getMolecWeight());
 }
@@ -2712,7 +2713,7 @@ void print_planet_details(planet* the_planet) {
   print_detail("SPH:", the_planet->getSph());
   print_detail("ESI:", the_planet->getEsi());
   print_detail("Density:", the_planet->getDensity(), "grams/cc");
-  print_detail("Escape Velocity:", the_planet->getEscVelocity() / CM_PER_KM, "Km/sec");
+  print_detail("Escape Velocity:", sgu::cm_to_km(the_planet->getEscVelocity()), "Km/sec");
   print_detail("Surface acceleration:", the_planet->getSurfAccel(), "cm/sec2");
   print_detail("Surface gravity:", the_planet->getSurfGrav(), "Earth gees");
   print_detail("Surface temperature:", the_planet->getSurfTemp() - FREEZING_POINT_OF_WATER,

--- a/enviro.cpp
+++ b/enviro.cpp
@@ -1205,7 +1205,7 @@ long double opacity(long double molecular_weight, long double surf_pressure, lon
 auto gas_life(long double molecular_weight, planet *the_planet) -> long double {
   long double v = rms_vel(molecular_weight, the_planet->getExosphericTemp());
   long double g = the_planet->getSurfGrav() * EARTH_ACCELERATION;
-  long double r = the_planet->getRadius() * CM_PER_KM;
+  long double r = sgu::km_to_cm(the_planet->getRadius());
   long double t =
       (pow3(v) / (2.0 * pow2(g) * r)) * exp((3.0 * g * r) / pow2(v));
   long double years = t / (SECONDS_PER_HOUR * 24.0 * DAYS_IN_A_YEAR);
@@ -2922,7 +2922,7 @@ auto calcOblateness(planet *the_planet) -> long double {
                                (mass_in_eu * std::pow(the_planet->getDay(), 2.0)));
   } else {
     planetary_mass_in_grams = the_planet->getMass() * SOLAR_MASS_IN_GRAMS;
-    equatorial_radius_in_cm = the_planet->getRadius() * CM_PER_KM;
+    equatorial_radius_in_cm = sgu::km_to_cm(the_planet->getRadius());
     k2 = calculate_moment_of_inertia_coeffient(the_planet);
     if (the_planet->getDay() == 0) {
       // Day length not yet calculated - return 0 oblateness as placeholder
@@ -3004,7 +3004,7 @@ auto calcEsiComponents(planet *the_planet) -> EsiComponents {
   return {
       calcEsiHelper(convert_km_to_eu(the_planet->getRadius()), 1.0, 0.57),
       calcEsiHelper(the_planet->getDensity() / EARTH_DENSITY, 1.0, 1.07),
-      calcEsiHelper((the_planet->getEscVelocity() / CM_PER_KM) / 11.186, 1.0, 0.70),
+      calcEsiHelper((sgu::cm_to_km(the_planet->getEscVelocity())) / 11.186, 1.0, 0.70),
       calcEsiHelper(the_planet->getSurfTemp(), EARTH_AVERAGE_KELVIN, 5.58)};
 }
 

--- a/structs.cpp
+++ b/structs.cpp
@@ -6,6 +6,7 @@
 #include <utility>      // for move
 #include "c_structs.h"  // for star2
 #include "const.h"      // for pow2, KM_PER_AU, ACCURACY_FOR_PEAK, CM_PER_KM
+#include "units.hh"     // au-backed exact length conversions (sgu::)
 #include "enviro.h"     // for eff_temp_to_spec_type, luminosity_to_mass
 #include "utils.h"      // for quicksort, fix_inclination, my_strtoupper
 
@@ -1240,7 +1241,7 @@ auto planet::getOblateness() -> long double {
     result = multiplier * (pow(radius, 3.0) / (mass_in_eu * std::pow(day, 2.0)));
   } else {
     planetary_mass_in_grams = getMass() * SOLAR_MASS_IN_GRAMS;
-    equatorial_radius_in_cm = radius * CM_PER_KM;
+    equatorial_radius_in_cm = sgu::km_to_cm(radius);
     k2 = calculate_moment_of_inertia_coeffient(the_planet);
     if (day == 0) {
       // Day length not yet calculated - return 0 oblateness as placeholder


### PR DESCRIPTION
## What

WU-2: completes the **byte-identical** exact-length-conversion migration started in #74. Routes the remaining km↔cm conversions through `units.hh`'s `au`-backed helpers (`sgu::km_to_cm` / `sgu::cm_to_km`) instead of literal `CM_PER_KM`:

- **display.cpp** — escape-velocity cm/s → km/s for display (3 sites)
- **structs.cpp** — planet radius km → cm in the moment-of-inertia / day-length path
- **enviro.cpp** — 3 km↔cm sites missed in WU-1 (`gas_life` radius, oblateness refinement, ESI escape-velocity term)

## Byte-identical
All factors are exact powers of ten (pinned `==` in `units_test`): `scripts/verify.sh --determinism` **PASS** — ctest **23/23**, 10× `-T8` + `-T1/-T2/-T4` byte-identical, ref `294147B` unchanged; **goldens unchanged**.

After this, every exact `CM_PER_KM`/`CM_PER_AU`/`CM_PER_METER` conversion in the generation/display code goes through `au`. The only length conversion still on a literal is `convert_au_to_km` — `au`'s AU→km differs ~1 ULP from `KM_PER_AU`, a deliberate rebaseline that remains deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)