### PR TITLE
feat(accrete): metallicity-dependent giant-formation gate (fix cold-giant over-production)

### DIFF
--- a/accrete.cpp
+++ b/accrete.cpp
@@ -885,6 +885,31 @@ auto accrete::dist_planetary_masses(sun &the_sun, long double inner_dust,
 
   // std::cout << planet_inner_bound << " " << planet_outer_bound << std::endl;
 
+  // --- Metallicity-dependent giant-formation gate (default-on; see const.h) -----
+  // Decide ONCE whether this star can form gas giants, from a per-star [Fe/H] draw
+  // and the observed giant-frequency-metallicity relation. Three fixed draws in a
+  // fixed order (Box-Muller [Fe/H] = 2 draws, then the acceptance draw) -> no
+  // rejection loops, serial == parallel byte-identical. If not giant-capable, gas
+  // runaway is suppressed below (crit_mass made unreachable) so bodies stay cores.
+  bool giant_capable = true;
+  {
+    const long double u1 = random_ctx->randDouble(1.0e-12L, 1.0L);  // avoid log(0)
+    const long double u2 = random_ctx->randDouble(0.0L, 1.0L);
+    const long double feh =
+        GIANT_METALLICITY_MEAN +
+        GIANT_METALLICITY_SIGMA * sqrt(-2.0L * log(u1)) * cos(2.0L * PI * u2);
+    long double p_giant = GIANT_FORMATION_NORM * stell_mass_ratio *
+                          std::pow(10.0L, GIANT_FORMATION_FEH_SLOPE * feh);
+    if (stell_mass_ratio > GIANT_FORMATION_MASS_TURNOVER_MSUN) {  // steep drop for A-stars
+      p_giant *= GIANT_FORMATION_MASS_TURNOVER_MSUN / stell_mass_ratio;
+    }
+    if (p_giant > GIANT_FORMATION_PROB_CAP) {
+      p_giant = GIANT_FORMATION_PROB_CAP;
+    }
+    const long double u_giant = random_ctx->randDouble(0.0L, 1.0L);
+    giant_capable = (u_giant < p_giant);
+  }
+
   // while there's still dust left...
   while (dust_left) {
     if (seeds != nullptr) {
@@ -952,6 +977,9 @@ auto accrete::dist_planetary_masses(sun &the_sun, long double inner_dust,
       dust_density = dust_density_coeff * sqrt(stell_mass_ratio) *
                      exp(-ALPHA * std::pow(a, 1.0 / NDENSITY));
       crit_mass = critical_limit(a, e, stell_luminosity_ratio);
+      if (!giant_capable) {
+        crit_mass = INCREDIBLY_LARGE_NUMBER;  // metallicity gate: suppress gas runaway -> rocky/ice core
+      }
       if (total_mass == PROTOPLANET_MASS && is_seed == false) {
         // std::cout << "test1\n";
         // std::cout << total_mass << " " << dust_mass << " " << gas_mass << " " << a
@@ -1009,6 +1037,9 @@ auto accrete::dist_planetary_masses(sun &the_sun, long double inner_dust,
       r_inner = inner_effect_limit(a, e, reduced_mass);
       r_outer = outer_effect_limit(a, e, reduced_mass);
       crit_mass = critical_limit(a, e, stell_luminosity_ratio);
+      if (!giant_capable) {
+        crit_mass = INCREDIBLY_LARGE_NUMBER;  // metallicity gate: suppress gas runaway -> rocky/ice core
+      }
       if (planet_inner_bound > a) {
         planet_inner_bound = a;
       }

--- a/const.h
+++ b/const.h
@@ -201,11 +201,28 @@ constexpr double MIGRATION_MIN_MASS_MJUP = 0.1;     // only bodies > 0.1 M_Jup m
 constexpr double MIGRATION_GAP_MASS_MJUP = 0.5;     // Type II gap-opening threshold (per M_star)
 constexpr double MIGRATION_TYPE1_NORM_YR = 1.1E5;   // Tanaka 2002 Type I normalization (yr)
 constexpr double MIGRATION_TYPE2_NORM_YR = 7.0E5;   // Type II viscous normalization at 1 AU (yr)
-constexpr double MIGRATION_EFFICIENCY    = 0.0001;     // overall rate multiplier (primary calibration knob)
+constexpr double MIGRATION_EFFICIENCY    = 0.0005;     // overall rate multiplier (primary calibration knob)
 constexpr double MIGRATION_INNER_EDGE_AU = 0.05;    // inner trap a_stop (disk edge / cavity)
 constexpr double MIGRATION_CIRC_AU       = 0.05;    // tidal circularization locus (hot -> e=0)
 constexpr double GIANT_ECC_SIGMA         = 0.215;   // Rayleigh sigma -> <e>~0.27 for cold giants
 constexpr double GIANT_ECC_MAX           = 0.80;    // eccentricity cap
+
+/* Metallicity-dependent giant-formation gate (default-on). StarGen's accretion
+ * forms a gas giant in ~84% of systems (crit_mass is low everywhere); the observed
+ * giant frequency is ~10-20% and rises steeply with stellar [Fe/H]. We draw a
+ * per-star [Fe/H] ~ N(mean,sigma) -- solar-neighborhood FGK metallicity distribution
+ * is ~Gaussian, mean ~0, sigma ~0.20 dex (Casagrande 2011; Nordstrom 2004) -- and
+ * accept the star as giant-capable with probability
+ *   P = NORM * (Mstar/Msun) * 10^(SLOPE*[Fe/H])   (Fischer & Valenti 2005 slope ~2.0),
+ * NORM calibrated so the population integrates to ~10-20% (closed form
+ * <P> = NORM*10^(SLOPE*mean)*exp((SLOPE*ln10)^2*sigma^2/2)). A non-giant-capable
+ * star has gas runaway suppressed (crit_mass made unreachable) -> rocky/ice cores. */
+constexpr double GIANT_METALLICITY_MEAN  = 0.0;    // dex (solar-centered FGK MDF)
+constexpr double GIANT_METALLICITY_SIGMA = 0.20;   // dex (Casagrande 2011 / Nordstrom 2004)
+constexpr double GIANT_FORMATION_NORM    = 0.10;   // calibration knob (-> ~12% integrated)
+constexpr double GIANT_FORMATION_FEH_SLOPE = 2.0;  // Fischer & Valenti 2005
+constexpr double GIANT_FORMATION_PROB_CAP = 0.90;  // cap (relation validated to [Fe/H]~+0.5)
+constexpr double GIANT_FORMATION_MASS_TURNOVER_MSUN = 2.0; // occurrence drops above ~2 Msun (Reffert 2015)
 
 // SI-unit physical constants used by the enviro.cpp acceleration helpers. These
 // are the EXACT values those functions previously redefined locally, kept

--- a/tests/golden/stargen_seed_12345.txt
+++ b/tests/golden/stargen_seed_12345.txt
@@ -2,356 +2,236 @@ Stargen - V$Revision: 3.0 $; seed=12345
                           SYSTEM  CHARACTERISTICS
 Stellar mass: 1 solar masses
 Stellar luminosity: 0.98401110576113374486
-Age: 2.9435951718504091879 billion years	(7.2188917568565470887 billion left on main sequence)
+Age: 6.4815260371461076243 billion years	(3.6809608915608486525 billion left on main sequence)
 Habitable ecosphere radius: 1.2491693971174707 AU
 
 Planets present at:
-1	0.32929052848992333358 AU	0.056881742499426778893 EM	.
-2	0.43925180315611207356 AU	0.004963935400002713156 EM	.
-3	0.45964674491661890242 AU	0.006096406370978955241 EM	.
-4	0.4778886148734016992 AU	0.06119851657504032232 EM	.
-5	0.61296553499806550697 AU	0.6397642960040522841 EM	o
-6	0.68775488031796824204 AU	0.06394021786138123063 EM	.
-7	0.928545262202229191 AU	0.15260228929772928803 EM	o
-8	1.2702814717675298573 AU	0.34868708360437104053 EM	o
-9	1.5232573688759141364 AU	1.3341239377847115686 EM	o
-10	2.2760469761771999595 AU	32.705540882521099498 EM	o
-11	3.0651501624522978849 AU	0.58856339012300186014 EM	o
-12	6.7178977055448094923 AU	654.4108902897903318 EM	o
-13	14.787668716492340532 AU	0.46684305473405767451 EM	o
-14	18.997848568563493705 AU	5.61696320492433811 EM	o
-15	26.744272453248485406 AU	2.3835069451012859004 EM	o
-16	44.658659885913400953 AU	0.90120455136914300455 EM	o
+1	0.40054153717485952915 AU	0.065243531846033140654 EM	.
+2	0.50512884802011209556 AU	0.33989126198523144325 EM	o
+3	0.8442227077290999972 AU	0.050287810984593018476 EM	.
+4	0.99777065491805143045 AU	0.94366287497415032984 EM	*
+5	1.631449462305043086 AU	11.185598456558811208 EM	o
+6	2.8092514578875065058 AU	39.68792072223448332 EM	o
+7	7.959597648554978254 AU	637.0102679808578648 EM	o
+8	20.117578589331890816 AU	86.33734878781949772 EM	o
+9	39.716157021457663863 AU	0.19822710537995828885 EM	o
+10	41.373875749196541932 AU	0.60927833032197686544 EM	o
+11	47.828605735883715496 AU	0.040159965489941242785 EM	.
 
 
 
 Planet 1
 Planet is tidally locked with one face to star.
-   Distance from primary star:	0.32929052848992333358 AU
-   Eccentricity of orbit:	0.0016653872956749951057
-   Length of year:		69.0186055070339832 days
-   Length of day:		1656.4465321688155968 hours
-   Mass:			0.056881742499426778893 Earth masses
-   Surface gravity:		0.21861210549303280975 Earth gees
+   Distance from primary star:	0.40054153717485952915 AU
+   Eccentricity of orbit:	0.0021345789677392779287
+   Length of year:		92.59097481832537684 days
+   Length of day:		2222.1833956398090442 hours
+   Mass:			0.065243531846033140654 Earth masses
+   Surface gravity:		0.23017263847087509196 Earth gees
    Surface pressure:		0 Earth atmospheres
-   Surface temperature:		200.78923439505848592 degrees Celcius
+   Surface temperature:		156.57290414036270931 degrees Celcius
    Boiling point of water:	-273.14999999999997726 degrees Celcius
    Hydrosphere percentage:	0%
    Cloud cover percentage:	0%
    Ice cover percentage:	0%
-   Equatorial radius:		2944.6535446731243397 Km
-   Density:			3.1786847294343791809 grams/cc
-   Escape Velocity:		3.925050546895378502 Km/sec
-   Molecular weight retained:	594.0119588020420158 and above
-   Surface acceleration:	214.38524043332501241 cm/sec2
+   Equatorial radius:		3061.0873887173325838 Km
+   Density:			3.2455436668140309633 grams/cc
+   Escape Velocity:		4.1229377508324570956 Km/sec
+   Molecular weight retained:	375.18782346837841157 and above
+   Surface acceleration:	225.72225050604071368 cm/sec2
    Axial tilt:			0 degrees
    Planetary albedo:		0.07000000000000000666
 
 
 Planet 2
 Planet is tidally locked with one face to star.
-   Distance from primary star:	0.43925180315611207356 AU
-   Eccentricity of orbit:	0.012652111351925964329
-   Length of year:		106.3329064866177643 days
-   Length of day:		2551.9897556788263433 hours
-   Mass:			0.004963935400002713156 Earth masses
-   Surface gravity:		0.07372817480977240649 Earth gees
+   Distance from primary star:	0.50512884802011209556 AU
+   Eccentricity of orbit:	1.3735048293617608909e-07
+   Length of year:		131.12949683964292487 days
+   Length of day:		3147.107924151430197 hours
+   Mass:			0.33989126198523144325 Earth masses
+   Surface gravity:		0.51892099178344003644 Earth gees
    Surface pressure:		0 Earth atmospheres
-   Surface temperature:		137.20100907620445696 degrees Celcius
+   Surface temperature:		106.653011444571689026 degrees Celcius
    Boiling point of water:	-273.14999999999997726 degrees Celcius
    Hydrosphere percentage:	0%
    Cloud cover percentage:	0%
    Ice cover percentage:	0%
-   Equatorial radius:		1515.3837312180888883 Km
-   Density:			2.035332830239851995 grams/cc
-   Escape Velocity:		1.6163211681524341111 Km/sec
-   Molecular weight retained:	1911.7873475130102814 and above
-   Surface acceleration:	72.30264054982545433 cm/sec2
+   Equatorial radius:		4742.097854233103817 Km
+   Density:			4.547844884106622231 grams/cc
+   Escape Velocity:		7.5606764711371518208 Km/sec
+   Molecular weight retained:	65.92696664297892799 and above
+   Surface acceleration:	508.88765440730720446 cm/sec2
    Axial tilt:			0 degrees
    Planetary albedo:		0.07000000000000000666
 
 
 Planet 3
 Planet is tidally locked with one face to star.
-   Distance from primary star:	0.45964674491661890242 AU
-   Eccentricity of orbit:	0.019839922781041273124
-   Length of year:		113.8239461776287372 days
-   Length of day:		2731.7747082630896929 hours
-   Mass:			0.006096406370978955241 Earth masses
-   Surface gravity:		0.08376635117501964303 Earth gees
+   Distance from primary star:	0.8442227077290999972 AU
+   Eccentricity of orbit:	0.011553298545338104278
+   Length of year:		283.3236775008013619 days
+   Length of day:		6799.7682600192326854 hours
+   Mass:			0.050287810984593018476 Earth masses
+   Surface gravity:		0.19890189202909141869 Earth gees
    Surface pressure:		0 Earth atmospheres
-   Surface temperature:		127.99389562264207143 degrees Celcius
+   Surface temperature:		22.844585951267220025 degrees Celcius
    Boiling point of water:	-273.14999999999997726 degrees Celcius
    Hydrosphere percentage:	0%
    Cloud cover percentage:	0%
    Ice cover percentage:	0%
-   Equatorial radius:		1593.6654592970267081 Km
-   Density:			2.1491147589492861321 grams/cc
-   Escape Velocity:		1.7466837689507965115 Km/sec
-   Molecular weight retained:	1462.8367355939337515 and above
-   Surface acceleration:	82.14672877505063519 cm/sec2
+   Equatorial radius:		2864.42712013378672 Km
+   Density:			3.0529984145673007162 grams/cc
+   Escape Velocity:		3.7418673501092905645 Km/sec
+   Molecular weight retained:	104.36148761303361626 and above
+   Surface acceleration:	195.05612394670892888 cm/sec2
    Axial tilt:			0 degrees
    Planetary albedo:		0.07000000000000000666
 
 
 Planet 4
-Planet is tidally locked with one face to star.
-   Distance from primary star:	0.4778886148734016992 AU
-   Eccentricity of orbit:	0.001759429192365152608
-   Length of year:		120.66667476436553169 days
-   Length of day:		2896.0001943447727606 hours
-   Mass:			0.06119851657504032232 Earth masses
-   Surface gravity:		0.23548226225343775991 Earth gees
-   Surface pressure:		0 Earth atmospheres
-   Surface temperature:		120.26321146684034602 degrees Celcius
-   Boiling point of water:	-273.14999999999997726 degrees Celcius
-   Hydrosphere percentage:	0%
-   Cloud cover percentage:	0%
-   Ice cover percentage:	0%
-   Equatorial radius:		2984.6087151385529235 Km
-   Density:			3.2843986505500408716 grams/cc
-   Escape Velocity:		4.043920941979122581 Km/sec
-   Molecular weight retained:	258.60685617152365923 and above
-   Surface acceleration:	230.92921271276753226 cm/sec2
-   Axial tilt:			0 degrees
-   Planetary albedo:		0.07000000000000000666
+   Distance from primary star:	0.99777065491805143045 AU
+   Eccentricity of orbit:	2.6835212704294321608e-08
+   Length of year:		364.0347423430237626 days
+   Length of day:		18.583985582733506115 hours
+   Mass:			0.94366287497415032984 Earth masses
+   Surface gravity:		0.8360380397709321304 Earth gees
+   Surface pressure:		0.7555155512163534486 Earth atmospheres
+   Surface temperature:		6.8386773083695555353 degrees Celcius
+   Boiling point of water:	92.63194717858101512 degrees Celcius
+   Hydrosphere percentage:	69.96401402640827817%
+   Cloud cover percentage:	29.622627601387067967%
+   Ice cover percentage:	4.7736305658553780215%
+   Equatorial radius:		6241.573564623465994 Km
+   Density:			5.5374748551964638986 grams/cc
+   Escape Velocity:		10.980883865874730982 Km/sec
+   Molecular weight retained:	7.5151524825679891367 and above
+   Surface acceleration:	819.87324427196112725 cm/sec2
+   Axial tilt:			74.00574308363074749 degrees
+   Planetary albedo:		0.25599133961300346408
 
 
-Planet 5
-Planet is tidally locked with one face to star.
-   Distance from primary star:	0.61296553499806550697 AU
-   Eccentricity of orbit:	9.3638212342158537206e-11
-   Length of year:		175.28753174684774581 days
-   Length of day:		4206.9007619243458995 hours
-   Mass:			0.6397642960040522841 Earth masses
-   Surface gravity:		0.6837252725731402081 Earth gees
-   Surface pressure:		0 Earth atmospheres
-   Surface temperature:		68.810702504833557214 degrees Celcius
-   Boiling point of water:	-273.14999999999997726 degrees Celcius
-   Hydrosphere percentage:	0%
-   Cloud cover percentage:	0%
-   Ice cover percentage:	0%
-   Equatorial radius:		5639.066714542268575 Km
-   Density:			5.0906762657623624833 grams/cc
-   Escape Velocity:		9.512228927489760099 Km/sec
-   Molecular weight retained:	27.110964069821037969 and above
-   Surface acceleration:	670.5054444279385173 cm/sec2
-   Axial tilt:			0 degrees
-   Planetary albedo:		0.07000000000000000666
+Planet 5	*gas giant*
+   Distance from primary star:	1.631449462305043086 AU
+   Eccentricity of orbit:	2.7806932890349511628e-54
+   Length of year:		761.11537941988655065 days
+   Length of day:		17.731701276783798243 hours
+   Mass:			11.185598456558811208 Earth masses
+   Equatorial radius:		37611.53968673472573 Km
+   Density:			0.29996671440320114843 grams/cc
+   Escape Velocity:		19.940517824701822828 Km/sec
+   Molecular weight retained:	0.50271222311045160114 and above
+   Surface acceleration:	706.50304495173139796 cm/sec2
+   Axial tilt:			28.704673959321425514 degrees
+   Planetary albedo:		0.75148146328545826984
 
 
-Planet 6
-Planet is tidally locked with one face to star.
-   Distance from primary star:	0.68775488031796824204 AU
-   Eccentricity of orbit:	0.0058254442030081258342
-   Length of year:		208.32809293116259253 days
-   Length of day:		4999.8742303479022207 hours
-   Mass:			0.06394021786138123063 Earth masses
-   Surface gravity:		0.2242137745587798125 Earth gees
-   Surface pressure:		0 Earth atmospheres
-   Surface temperature:		54.79079245504829032 degrees Celcius
-   Boiling point of water:	-273.14999999999997726 degrees Celcius
-   Hydrosphere percentage:	0%
-   Cloud cover percentage:	0%
-   Ice cover percentage:	0%
-   Equatorial radius:		3052.231806528574659 Km
-   Density:			3.2084756586342641329 grams/cc
-   Escape Velocity:		4.0874665294142329365 Km/sec
-   Molecular weight retained:	128.13356776492606268 and above
-   Surface acceleration:	219.87860122768579667 cm/sec2
-   Axial tilt:			0 degrees
-   Planetary albedo:		0.07000000000000000666
+Planet 6	*gas giant*
+   Distance from primary star:	2.8092514578875065058 AU
+   Eccentricity of orbit:	1.6349021117159812542e-110
+   Length of year:		1719.7185860413260302 days
+   Length of day:		14.245532269666840815 hours
+   Mass:			39.68792072223448332 Earth masses
+   Equatorial radius:		53462.098852205367038 Km
+   Density:			0.3705932553001998518 grams/cc
+   Escape Velocity:		30.527676188848922029 Km/sec
+   Molecular weight retained:	0.45758854976380989988 and above
+   Surface acceleration:	1089.1029497477711948 cm/sec2
+   Axial tilt:			100.65782740652980465 degrees
+   Planetary albedo:		0.57368296070164202165
 
 
-Planet 7
-   Distance from primary star:	0.928545262202229191 AU
-   Eccentricity of orbit:	0.0021259031785267082753
-   Length of year:		326.81492129378319358 days
-   Length of day:		34.192086437735849803 hours
-   Mass:			0.15260228929772928803 Earth masses
-   Surface gravity:		0.36453170024843415764 Earth gees
-   Surface pressure:		0 Earth atmospheres
-   Surface temperature:		8.600600358432018311 degrees Celcius
-   Boiling point of water:	-273.14999999999997726 degrees Celcius
-   Hydrosphere percentage:	0%
-   Cloud cover percentage:	0%
-   Ice cover percentage:	0%
-   Equatorial radius:		3810.4220903351437042 Km
-   Density:			3.9356726457418137767 grams/cc
-   Escape Velocity:		5.6515801581336499657 Km/sec
-   Molecular weight retained:	34.544802798919132764 and above
-   Surface acceleration:	357.48347982413066995 cm/sec2
-   Axial tilt:			89.55346124925598872 degrees
-   Planetary albedo:		0.07000000000000000666
+Planet 7	*gas giant*
+   Distance from primary star:	7.959597648554978254 AU
+   Eccentricity of orbit:	0
+   Length of year:		8194.430159714670396 days
+   Length of day:		8.714147414100174071 hours
+   Mass:			637.0102679808578648 Earth masses
+   Equatorial radius:		70775.15450814080515 Km
+   Density:			2.5637822276066188688 grams/cc
+   Escape Velocity:		78.12528047130434774 Km/sec
+   Molecular weight retained:	0.5156447640660151997 and above
+   Surface acceleration:	2335.4941750686702127 cm/sec2
+   Axial tilt:			122.70122100780430685 degrees
+   Planetary albedo:		0.51297508561606895526
 
 
-Planet 8
-Cold for the habitable zone: outgassed CO2 may freeze out, risking irreversible glaciation.
-   Distance from primary star:	1.2702814717675298573 AU
-   Eccentricity of orbit:	9.4400867972548216637e-05
-   Length of year:		522.9342371302939614 days
-   Length of day:		22.048677455701886146 hours
-   Mass:			0.34868708360437104053 Earth masses
-   Surface gravity:		0.48661445843022394954 Earth gees
-   Surface pressure:		0.097336401273387863935 Earth atmospheres
-   Surface temperature:		-66.721998088062367024 degrees Celcius
-   Boiling point of water:	45.360226311924236597 degrees Celcius
-   Hydrosphere percentage:	0%
-   Cloud cover percentage:	0.32879565359756038535%
-   Ice cover percentage:	64.73379248151745729%
-   Equatorial radius:		4830.822182028660714 Km
-   Density:			4.4131621317767781923 grams/cc
-   Escape Velocity:		7.5872311369869695043 Km/sec
-   Molecular weight retained:	10.709709501031676319 and above
-   Surface acceleration:	477.20576787647555178 cm/sec2
-   Axial tilt:			96.82980636511956618 degrees
-   Planetary albedo:		0.5063482145192636669
+Planet 8	*gas giant*
+   Distance from primary star:	20.117578589331890816 AU
+   Eccentricity of orbit:	2.5670767777504612695e-35
+   Length of year:		32953.73067028815294 days
+   Length of day:		14.275929478776329946 hours
+   Mass:			86.33734878781949772 Earth masses
+   Equatorial radius:		45217.265334020647384 Km
+   Density:			1.3324870792642474988 grams/cc
+   Escape Velocity:		37.035218602210315874 Km/sec
+   Molecular weight retained:	0.49854231922112245237 and above
+   Surface acceleration:	684.78745691628670617 cm/sec2
+   Axial tilt:			69.59133988771881718 degrees
+   Planetary albedo:		0.3132867333205057271
 
 
 Planet 9
-Cold for the habitable zone: outgassed CO2 may freeze out, risking irreversible glaciation.
-   Distance from primary star:	1.5232573688759141364 AU
-   Eccentricity of orbit:	2.9944616841109548981e-09
-   Length of year:		686.6831959988640101 days
-   Length of day:		15.911815690591683881 hours
-   Mass:			1.3341239377847115686 Earth masses
-   Surface gravity:		0.9042707309154371695 Earth gees
-   Surface pressure:		1.4280270572253124658 Earth atmospheres
-   Surface temperature:		-111.429028748299325954 degrees Celcius
-   Boiling point of water:	110.31313271965552758 degrees Celcius
+   Distance from primary star:	39.716157021457663863 AU
+   Eccentricity of orbit:	0.19137630676476437234
+   Length of year:		91421.44006209554643 days
+   Length of day:		27.510437973329610283 hours
+   Mass:			0.19822710537995828885 Earth masses
+   Surface gravity:		0.21991036236375892712 Earth gees
+   Surface pressure:		3.5793074323861954296e-05 Earth atmospheres
+   Surface temperature:		-240.73018310247026126 degrees Celcius
+   Boiling point of water:	-60.62987028002629586 degrees Celcius
    Hydrosphere percentage:	0%
-   Cloud cover percentage:	0.19737731211459621806%
+   Cloud cover percentage:	1.074071758004557964e-09%
    Ice cover percentage:	100%
-   Equatorial radius:		6939.2851872803266615 Km
-   Density:			5.6967760389771523117 grams/cc
-   Escape Velocity:		12.382736477829637006 Km/sec
-   Molecular weight retained:	2.6621136409399442843 and above
-   Surface acceleration:	886.78665633318715894 cm/sec2
-   Axial tilt:			67.517838395778284166 degrees
-   Planetary albedo:		0.6996447208381936825
+   Equatorial radius:		4635.493541855359222 Km
+   Density:			2.8395680201480868222 grams/cc
+   Escape Velocity:		5.839954182509946404 Km/sec
+   Molecular weight retained:	0.044233743276412612416 and above
+   Surface acceleration:	215.65839550745564025 cm/sec2
+   Axial tilt:			129.32586001868762082 degrees
+   Planetary albedo:		0.69999999999806662644
 
 
-Planet 10	*gas giant*
-   Distance from primary star:	2.2760469761771999595 AU
-   Eccentricity of orbit:	5.488169651649801356e-112
-   Length of year:		1254.145286907297711 days
-   Length of day:		14.573735191654934667 hours
-   Mass:			32.705540882521099498 Earth masses
-   Equatorial radius:		52055.716499819402177 Km
-   Density:			0.33082112071094380056 grams/cc
-   Escape Velocity:		28.756720956383538432 Km/sec
-   Molecular weight retained:	0.4647150971777250272 and above
-   Surface acceleration:	1089.0001269402297837 cm/sec2
-   Axial tilt:			157.31662060595715502 degrees
-   Planetary albedo:		0.586051974960612294
+Planet 10
+   Distance from primary star:	41.373875749196541932 AU
+   Eccentricity of orbit:	0.03579174673311559836
+   Length of year:		97204.47746157843094 days
+   Length of day:		22.059664891224102378 hours
+   Mass:			0.60927833032197686544 Earth masses
+   Surface gravity:		0.34307412843373475566 Earth gees
+   Surface pressure:		0.04582158158222928005 Earth atmospheres
+   Surface temperature:		-241.75724264762581228 degrees Celcius
+   Boiling point of water:	30.912872827759713346 degrees Celcius
+   Hydrosphere percentage:	0%
+   Cloud cover percentage:	2.2267045292560424993e-07%
+   Ice cover percentage:	100%
+   Equatorial radius:		6516.6400493434982786 Km
+   Density:			3.1413889452017614984 grams/cc
+   Escape Velocity:		8.6351902423671935685 Km/sec
+   Molecular weight retained:	0.017787068366988922917 and above
+   Surface acceleration:	336.44079016046848168 cm/sec2
+   Axial tilt:			130.67114708787468658 degrees
+   Planetary albedo:		0.69999999959919314034
 
 
 Planet 11
-   Distance from primary star:	3.0651501624522978849 AU
-   Eccentricity of orbit:	0.06952887599742213382
-   Length of year:		1960.0836590924733526 days
-   Length of day:		18.897858651513793269 hours
-   Mass:			0.58856339012300186014 Earth masses
-   Surface gravity:		0.6410693613109143012 Earth gees
-   Surface pressure:		0.28162735772404009978 Earth atmospheres
-   Surface temperature:		-150.07757570252103108 degrees Celcius
-   Boiling point of water:	68.23327789790562292 degrees Celcius
+   Distance from primary star:	47.828605735883715496 AU
+   Eccentricity of orbit:	0.056803301162130563046
+   Length of year:		120817.24096819515237 days
+   Length of day:		38.013531083601318477 hours
+   Mass:			0.040159965489941242785 Earth masses
+   Surface gravity:		0.1102838733671054799 Earth gees
+   Surface pressure:		1.5104544365216758299e-06 Earth atmospheres
+   Surface temperature:		-243.51342594933408847 degrees Celcius
+   Boiling point of water:	-85.60928001759762651 degrees Celcius
    Hydrosphere percentage:	0%
-   Cloud cover percentage:	0.0012326947942812527297%
-   Ice cover percentage:	83.97814504248175877%
-   Equatorial radius:		5486.5197712423494556 Km
-   Density:			5.084866756090854682 grams/cc
-   Escape Velocity:		9.249623564265157329 Km/sec
-   Molecular weight retained:	1.2383962278203907234 and above
-   Surface acceleration:	628.6742852099677499 cm/sec2
-   Axial tilt:			85.078071238926440856 degrees
-   Planetary albedo:		0.61188096879370420226
-
-
-Planet 12	*gas giant*
-   Distance from primary star:	6.7178977055448094923 AU
-   Eccentricity of orbit:	0
-   Length of year:		6353.614089634039738 days
-   Length of day:		8.543747551365498908 hours
-   Mass:			654.4108902897903318 Earth masses
-   Equatorial radius:		71635.99862723077694 Km
-   Density:			2.5400001241802022624 grams/cc
-   Escape Velocity:		79.43389497486418113 Km/sec
-   Molecular weight retained:	0.48573505113377613522 and above
-   Surface acceleration:	2716.543020056535514 cm/sec2
-   Axial tilt:			46.50285739354377057 degrees
-   Planetary albedo:		0.52122502967122540427
-
-
-Planet 13
-   Distance from primary star:	14.787668716492340532 AU
-   Eccentricity of orbit:	0.037070763161740593796
-   Length of year:		20770.484304947398181 days
-   Length of day:		23.369794730894127304 hours
-   Mass:			0.46684305473405767451 Earth masses
-   Surface gravity:		0.30047143608415432178 Earth gees
-   Surface pressure:		0.05699851663028714531 Earth atmospheres
-   Surface temperature:		-220.43972041891551565 degrees Celcius
-   Boiling point of water:	34.961720005963002222 degrees Celcius
-   Hydrosphere percentage:	0%
-   Cloud cover percentage:	2.477844278690356997e-06%
+   Cloud cover percentage:	4.1645556044370017022e-10%
    Ice cover percentage:	100%
-   Equatorial radius:		6043.065516762530608 Km
-   Density:			3.0183956909625075178 grams/cc
-   Escape Velocity:		7.8493322076506505253 Km/sec
-   Molecular weight retained:	0.17109849693197500343 and above
-   Surface acceleration:	294.66182086746718705 cm/sec2
-   Axial tilt:			11.801560142143303622 degrees
-   Planetary albedo:		0.6999999955398802539
-
-
-Planet 14	*gas giant*
-   Distance from primary star:	18.997848568563493705 AU
-   Eccentricity of orbit:	0.004494564219160512889
-   Length of year:		30244.772765580602988 days
-   Length of day:		25.08412678938768658 hours
-   Mass:			5.61696320492433811 Earth masses
-   Equatorial radius:		45138.236184789431167 Km
-   Density:			0.08714550747614343706 grams/cc
-   Escape Velocity:		14.110530227447829675 Km/sec
-   Molecular weight retained:	0.028582739011099345613 and above
-   Surface acceleration:	211.772361981846014 cm/sec2
-   Axial tilt:			85.71261695304124828 degrees
-   Planetary albedo:		0.31519050946881018913
-
-
-Planet 15	*gas giant*
-   Distance from primary star:	26.744272453248485406 AU
-   Eccentricity of orbit:	0.00073642312520735097544
-   Length of year:		50517.515723690898902 days
-   Length of day:		30.816081388072626283 hours
-   Mass:			2.3835069451012859004 Earth masses
-   Equatorial radius:		39449.645877237770648 Km
-   Density:			0.055394197198158686227 grams/cc
-   Escape Velocity:		10.275023681876668706 Km/sec
-   Molecular weight retained:	0.02805229703018419299 and above
-   Surface acceleration:	165.88642819534009831 cm/sec2
-   Axial tilt:			56.343969797334494842 degrees
-   Planetary albedo:		0.27609748458675940135
-
-
-Planet 16
-   Distance from primary star:	44.658659885913400953 AU
-   Eccentricity of orbit:	0.13607306311658803029
-   Length of year:		109007.2291973598898 days
-   Length of day:		20.52166255372142881 hours
-   Mass:			0.90120455136914300455 Earth masses
-   Surface gravity:		0.37757696330671732722 Earth gees
-   Surface pressure:		0.094627783609434760484 Earth atmospheres
-   Surface temperature:		-243.14449844206093705 degrees Celcius
-   Boiling point of water:	44.794343601212119665 degrees Celcius
-   Hydrosphere percentage:	0%
-   Cloud cover percentage:	2.3156408776934876361e-07%
-   Ice cover percentage:	100%
-   Equatorial radius:		7372.948264348540048 Km
-   Density:			3.208314951319429325 grams/cc
-   Escape Velocity:		9.873406217428011587 Km/sec
-   Molecular weight retained:	0.0113553334853034762465 and above
-   Surface acceleration:	370.27651272118193396 cm/sec2
-   Axial tilt:			44.719731576225939307 degrees
-   Planetary albedo:		0.6999999995831845976
+   Equatorial radius:		2883.0477465504667722 Km
+   Density:			2.3911950589719174478 grams/cc
+   Escape Velocity:		3.3330870670809480362 Km/sec
+   Molecular weight retained:	0.09483071355221334032 and above
+   Surface acceleration:	108.151534675552491435 cm/sec2
+   Axial tilt:			158.25295957073478803 degrees
+   Planetary albedo:		0.6999999999992503356

--- a/tests/golden/stargen_seed_42.txt
+++ b/tests/golden/stargen_seed_42.txt
@@ -2,215 +2,310 @@ Stargen - V$Revision: 3.0 $; seed=42
                           SYSTEM  CHARACTERISTICS
 Stellar mass: 1 solar masses
 Stellar luminosity: 0.98401110576113374486
-Age: 7.5663580299171949166 billion years	(2.5961288987897613602 billion left on main sequence)
+Age: 6.9171439760008882084 billion years	(3.2453429527060680684 billion left on main sequence)
 Habitable ecosphere radius: 1.2491693971174707 AU
 
 Planets present at:
-1	0.3556694362521560706 AU	0.03519412665792341447 EM	.
-2	0.42887140693515651837 AU	0.065021642960036551685 EM	.
-3	0.55768756950593494423 AU	0.4055982691315685622 EM	o
-4	0.9615657911871555064 AU	0.70275157781690689954 EM	*
-5	1.4462026994367287258 AU	3.1032148593715900868 EM	o
-6	1.9426215771489064492 AU	0.27758054499394701307 EM	o
-7	3.1043340577887717998 AU	159.74343576212183828 EM	o
-8	7.4028224921029219642 AU	752.70051400799445324 EM	o
-9	22.601650198597053517 AU	24.417949024602892162 EM	o
-10	39.888186319105942656 AU	2.0594285295155744181 EM	o
+1	0.33764668262485916794 AU	0.12209468942370160976 EM	o
+2	0.651195539552810333 AU	1.3361937142075943206 EM	+
+3	0.9794968656237077487 AU	0.46487515174906930636 EM	*
+4	1.6725535889618004424 AU	0.28855601873521071997 EM	o
+5	1.8562706021562373789 AU	1.7185087815592084462 EM	o
+6	2.6192837138736725124 AU	5.340744482106013415 EM	o
+7	4.044709044204691859 AU	0.54539097948699600426 EM	o
+8	5.268753551028884898 AU	10.676186076420129436 EM	o
+9	8.513766991968543736 AU	0.16637302211024558224 EM	o
+10	11.8687356167491953034 AU	2.0981149032433221494 EM	o
+11	16.88531799247696869 AU	4.067525644127660672 EM	o
+12	30.552695561225659313 AU	1.422646223162282839 EM	o
+13	48.68595445511129124 AU	0.10742264348463640272 EM	o
 
 
 
 Planet 1
 Planet is tidally locked with one face to star.
-   Distance from primary star:	0.3556694362521560706 AU
-   Eccentricity of orbit:	0.0067632346312028906692
-   Length of year:		77.475993779557056115 days
-   Length of day:		1859.4238507093693468 hours
-   Mass:			0.03519412665792341447 Earth masses
-   Surface gravity:		0.16942944604091666691 Earth gees
+   Distance from primary star:	0.33764668262485916794 AU
+   Eccentricity of orbit:	3.2183357952220920727e-05
+   Length of year:		71.662344067103721505 days
+   Length of day:		1719.8962576104893161 hours
+   Mass:			0.12209468942370160976 Earth masses
+   Surface gravity:		0.32376855595103919017 Earth gees
    Surface pressure:		0 Earth atmospheres
-   Surface temperature:		182.87537476903878542 degrees Celcius
+   Surface temperature:		194.54791489374201774 degrees Celcius
    Boiling point of water:	-273.14999999999997726 degrees Celcius
    Hydrosphere percentage:	0%
    Cloud cover percentage:	0%
    Ice cover percentage:	0%
-   Equatorial radius:		2599.6316794758790765 Km
-   Density:			2.8583269809894631189 grams/cc
-   Escape Velocity:		3.2859057049735012697 Km/sec
-   Molecular weight retained:	762.9096429881898256 and above
-   Surface acceleration:	166.153527701715537 cm/sec2
+   Equatorial radius:		3596.651001750070448 Km
+   Density:			3.744372590273888263 grams/cc
+   Escape Velocity:		5.2032554579651186942 Km/sec
+   Molecular weight retained:	319.89264451646681306 and above
+   Surface acceleration:	317.50849092172583565 cm/sec2
    Axial tilt:			0 degrees
    Planetary albedo:		0.07000000000000000666
 
 
 Planet 2
 Planet is tidally locked with one face to star.
-   Distance from primary star:	0.42887140693515651837 AU
-   Eccentricity of orbit:	0.00075195415888674206677
-   Length of year:		102.58596667359151544 days
-   Length of day:		2462.0632001661963706 hours
-   Mass:			0.065021642960036551685 Earth masses
-   Surface gravity:		0.22743888264808251621 Earth gees
-   Surface pressure:		0 Earth atmospheres
-   Surface temperature:		142.13738210578651433 degrees Celcius
-   Boiling point of water:	-273.14999999999997726 degrees Celcius
+   Distance from primary star:	0.651195539552810333 AU
+   Eccentricity of orbit:	0.008465015522773332423
+   Length of year:		191.93917003752067742 days
+   Length of day:		4606.540080900496258 hours
+   Mass:			1.3361937142075943206 Earth masses
+   Surface gravity:		0.91111225695574389204 Earth gees
+   Surface pressure:		201.49776459749413454 Earth atmospheres GREENHOUSE EFFECT
+   Surface temperature:		842.4061910826718428 degrees Celcius
+   Boiling point of water:	341.17090567833793102 degrees Celcius
    Hydrosphere percentage:	0%
-   Cloud cover percentage:	0%
+   Cloud cover percentage:	100%
    Ice cover percentage:	0%
-   Equatorial radius:		3063.042548852137478 Km
-   Density:			3.2283159239584053152 grams/cc
-   Escape Velocity:		4.114607042738421005 Km/sec
-   Molecular weight retained:	332.36306332419092113 and above
-   Surface acceleration:	223.0413518520818325 cm/sec2
+   Equatorial radius:		6934.965184403206857 Km
+   Density:			5.7162833383490264257 grams/cc
+   Escape Velocity:		12.396197303883079439 Km/sec
+   Molecular weight retained:	14.404095191568696107 and above
+   Surface acceleration:	893.4959014675045507 cm/sec2
    Axial tilt:			0 degrees
-   Planetary albedo:		0.07000000000000000666
+   Planetary albedo:		0.52000000000000001776
 
 
 Planet 3
-Planet is tidally locked with one face to star.
-   Distance from primary star:	0.55768756950593494423 AU
-   Eccentricity of orbit:	5.0182637388387439404e-08
-   Length of year:		152.119027665737124 days
-   Length of day:		3650.8566639776909761 hours
-   Mass:			0.4055982691315685622 Earth masses
-   Surface gravity:		0.56366112082088391094 Earth gees
-   Surface pressure:		0 Earth atmospheres
-   Surface temperature:		87.625632933297481486 degrees Celcius
-   Boiling point of water:	-273.14999999999997726 degrees Celcius
-   Hydrosphere percentage:	0%
-   Cloud cover percentage:	0%
-   Ice cover percentage:	0%
-   Equatorial radius:		4973.098261676042377 Km
-   Density:			4.7053523492848449766 grams/cc
-   Escape Velocity:		8.065112630201446591 Km/sec
-   Molecular weight retained:	47.33946226972334105 and above
-   Surface acceleration:	552.7627330498121 cm/sec2
-   Axial tilt:			0 degrees
-   Planetary albedo:		0.07000000000000000666
+   Distance from primary star:	0.9794968656237077487 AU
+   Eccentricity of orbit:	0.019297659201774081741
+   Length of year:		354.08019136234954033 days
+   Length of day:		24.588716607856364297 hours
+   Mass:			0.46487515174906930636 Earth masses
+   Surface gravity:		0.5467896283181687306 Earth gees
+   Surface pressure:		0.17113622090567622899 Earth atmospheres
+   Surface temperature:		1.7514114369904083268 degrees Celcius
+   Boiling point of water:	57.113237387611263784 degrees Celcius
+   Hydrosphere percentage:	46.154803804072007507%
+   Cloud cover percentage:	13.55115097972437297%
+   Ice cover percentage:	8.108491125554663868%
+   Equatorial radius:		5233.4311085486808026 Km
+   Density:			4.627580438492953997 grams/cc
+   Escape Velocity:		8.416873909429531777 Km/sec
+   Molecular weight retained:	14.90769444125612451 and above
+   Surface acceleration:	536.2174508546369183 cm/sec2
+   Axial tilt:			98.30683310296366528 degrees
+   Planetary albedo:		0.1817416980873317137
 
 
 Planet 4
 Cold for the habitable zone: outgassed CO2 may freeze out, risking irreversible glaciation.
-   Distance from primary star:	0.9615657911871555064 AU
-   Eccentricity of orbit:	4.9328309678401348442e-08
-   Length of year:		344.40179538610635435 days
-   Length of day:		21.515817643376124688 hours
-   Mass:			0.70275157781690689954 Earth masses
-   Surface gravity:		0.74694632601669362464 Earth gees
-   Surface pressure:		0.42559740364092432492 Earth atmospheres
-   Surface temperature:		-3.1304337038798510096 degrees Celcius
-   Boiling point of water:	78.03490389828255047 degrees Celcius
-   Hydrosphere percentage:	48.209193604465772204%
-   Cloud cover percentage:	13.3795208153624547555%
-   Ice cover percentage:	10.833882735362008061%
-   Equatorial radius:		5743.1176891500479327 Km
-   Density:			5.293413974251120997 grams/cc
-   Escape Velocity:		9.878772113210427342 Km/sec
-   Molecular weight retained:	10.126051846552090937 and above
-   Surface acceleration:	732.50411880316082625 cm/sec2
-   Axial tilt:			80.57455619657328327 degrees
-   Planetary albedo:		0.24182132993760131443
+   Distance from primary star:	1.6725535889618004424 AU
+   Eccentricity of orbit:	0.0016030060765626794834
+   Length of year:		790.0730224346516133 days
+   Length of day:		22.616518338577286974 hours
+   Mass:			0.28855601873521071997 Earth masses
+   Surface gravity:		0.4722135231400785934 Earth gees
+   Surface pressure:		0.22928612898060787838 Earth atmospheres
+   Surface temperature:		-90.94410126443710746 degrees Celcius
+   Boiling point of water:	38.6951152931878255 degrees Celcius
+   Hydrosphere percentage:	0%
+   Cloud cover percentage:	0.047411578252968787856%
+   Ice cover percentage:	60.375130638503946946%
+   Equatorial radius:		4550.4534320666276823 Km
+   Density:			4.3696161978533030025 grams/cc
+   Escape Velocity:		7.111539751058059046 Km/sec
+   Molecular weight retained:	6.9521898390997020145 and above
+   Surface acceleration:	463.0832746701651566 cm/sec2
+   Axial tilt:			102.48451207895675452 degrees
+   Planetary albedo:		0.48210825951111199955
 
 
 Planet 5
-Cold for the habitable zone: outgassed CO2 may freeze out, risking irreversible glaciation.
-   Distance from primary star:	1.4462026994367287258 AU
-   Eccentricity of orbit:	6.9140529623799072307e-20
-   Length of year:		635.2418261590967404 days
-   Length of day:		12.971935716754630617 hours
-   Mass:			3.1032148593715900868 Earth masses
-   Surface gravity:		1.4444531530124733227 Earth gees
-   Surface pressure:		3.9138413908882188077 Earth atmospheres
-   Surface temperature:		-108.35093612148614284 degrees Celcius
-   Boiling point of water:	168.8433133761652698 degrees Celcius
+   Distance from primary star:	1.8562706021562373789 AU
+   Eccentricity of orbit:	1.2248001418211693407e-09
+   Length of year:		923.75790431282458953 days
+   Length of day:		14.785997080929237538 hours
+   Mass:			1.7185087815592084462 Earth masses
+   Surface gravity:		1.11449737745720818 Earth gees
+   Surface pressure:		2.5264389541195032742 Earth atmospheres
+   Surface temperature:		-127.036894505048896534 degrees Celcius
+   Boiling point of water:	127.67567605313979584 degrees Celcius
    Hydrosphere percentage:	0%
-   Cloud cover percentage:	0.6935981816987111057%
+   Cloud cover percentage:	0.036102873472434219895%
    Ice cover percentage:	100%
-   Equatorial radius:		8610.611608582171818 Km
-   Density:			6.935647678350012497 grams/cc
-   Escape Velocity:		16.953713249703252223 Km/sec
-   Molecular weight retained:	1.4723164594490284166 and above
-   Surface acceleration:	1416.5246512989770985 cm/sec2
-   Axial tilt:			3.6773630688328355909 degrees
-   Planetary albedo:		0.698751523272942276
+   Equatorial radius:		7325.425310163640636 Km
+   Density:			6.237784975860307854 grams/cc
+   Escape Velocity:		13.678402085797390901 Km/sec
+   Molecular weight retained:	1.4031562123031538956 and above
+   Surface acceleration:	1092.9485706640730193 cm/sec2
+   Axial tilt:			92.705626571000053104 degrees
+   Planetary albedo:		0.69993501482774957406
 
 
 Planet 6
-   Distance from primary star:	1.9426215771489064492 AU
-   Eccentricity of orbit:	0.005310493481754619906
-   Length of year:		988.96173912839402775 days
-   Length of day:		22.592832495796639268 hours
-   Mass:			0.27758054499394701307 Earth masses
-   Surface gravity:		0.4768882339750642432 Earth gees
-   Surface pressure:		0.22183219257430353277 Earth atmospheres
-   Surface temperature:		-105.289287388997185715 degrees Celcius
-   Boiling point of water:	37.570871950526623095 degrees Celcius
+   Distance from primary star:	2.6192837138736725124 AU
+   Eccentricity of orbit:	1.0526317079318106218e-18
+   Length of year:		1548.3448276729565363 days
+   Length of day:		11.5861476458705793475 hours
+   Mass:			5.340744482106013415 Earth masses
+   Surface gravity:		1.668625971292683343 Earth gees
+   Surface pressure:		22.4917649113858586 Earth atmospheres
+   Surface temperature:		-151.41342734582281557 degrees Celcius
+   Boiling point of water:	211.82670494569202901 degrees Celcius
    Hydrosphere percentage:	0%
-   Cloud cover percentage:	0.014685891179248734195%
-   Ice cover percentage:	59.827792801059944572%
-   Equatorial radius:		4483.4431674958432685 Km
-   Density:			4.3947198510538005955 grams/cc
-   Escape Velocity:		7.0269131846916896757 Km/sec
-   Molecular weight retained:	5.2360350365072814037 and above
-   Surface acceleration:	467.6675999711563587 cm/sec2
-   Axial tilt:			132.83538715736384006 degrees
-   Planetary albedo:		0.47906681200244995264
+   Cloud cover percentage:	0.0036001798788684144775%
+   Ice cover percentage:	100%
+   Equatorial radius:		10132.700628834694445 Km
+   Density:			7.3249277266124509568 grams/cc
+   Escape Velocity:		20.502848606539000757 Km/sec
+   Molecular weight retained:	0.35673591734861276025 and above
+   Surface acceleration:	1636.3630881377392499 cm/sec2
+   Axial tilt:			72.23141640313851042 degrees
+   Planetary albedo:		0.69999351967621799243
 
 
-Planet 7	*gas giant*
-   Distance from primary star:	3.1043340577887717998 AU
-   Eccentricity of orbit:	3.8182082987536616788e-402
-   Length of year:		1997.3115810959429459 days
-   Length of day:		10.747295126250016759 hours
-   Mass:			159.74343576212183828 Earth masses
-   Equatorial radius:		64103.397743369886896 Km
-   Density:			0.8652807673026118147 grams/cc
-   Escape Velocity:		49.78217022844103165 Km/sec
-   Molecular weight retained:	0.47003591438320243352 and above
-   Surface acceleration:	1948.3363210460414348 cm/sec2
-   Axial tilt:			135.62027132234518945 degrees
-   Planetary albedo:		0.5691047834671430312
+Planet 7
+   Distance from primary star:	4.044709044204691859 AU
+   Eccentricity of orbit:	0.007653143024041489553
+   Length of year:		2971.172946816926286 days
+   Length of day:		20.65452944323328456 hours
+   Mass:			0.54539097948699600426 Earth masses
+   Surface gravity:		0.4653055656075725119 Earth gees
+   Surface pressure:		0.10213379906147522734 Earth atmospheres
+   Surface temperature:		-172.57828043002810622 degrees Celcius
+   Boiling point of water:	46.329560530633330018 degrees Celcius
+   Hydrosphere percentage:	0%
+   Cloud cover percentage:	0.00016435331166146790173%
+   Ice cover percentage:	100%
+   Equatorial radius:		5772.6256365849576184 Km
+   Density:			4.045432392435736553 grams/cc
+   Escape Velocity:		8.680468968281531706 Km/sec
+   Molecular weight retained:	0.9270796396967074598 and above
+   Surface acceleration:	456.30888249655008046 cm/sec2
+   Axial tilt:			50.218212352083256178 degrees
+   Planetary albedo:		0.6999997041640389649
 
 
-Planet 8	*gas giant*
-   Distance from primary star:	7.4028224921029219642 AU
-   Eccentricity of orbit:	7.107191887139722825e-809
-   Length of year:		7348.5686356207208365 days
-   Length of day:		8.365681005118085312 hours
-   Mass:			752.70051400799445324 Earth masses
-   Equatorial radius:		70235.7245640794951 Km
-   Density:			3.0997394443337806472 grams/cc
-   Escape Velocity:		83.13278610107040964 Km/sec
-   Molecular weight retained:	0.4794167975692833968 and above
-   Surface acceleration:	2337.029886064846918 cm/sec2
-   Axial tilt:			35.147671344688184547 degrees
-   Planetary albedo:		0.52761347082280924905
+Planet 8
+   Distance from primary star:	5.268753551028884898 AU
+   Eccentricity of orbit:	4.674587642694053697e-19
+   Length of year:		4417.252439933880464 days
+   Length of day:		11.196840403671514462 hours
+   Mass:			10.676186076420129436 Earth masses
+   Surface gravity:		1.4357401418199716278 Earth gees
+   Surface pressure:		32.289103356579869623 Earth atmospheres
+   Surface temperature:		-187.78198008014178791 degrees Celcius
+   Boiling point of water:	229.2712478877446074 degrees Celcius
+   Hydrosphere percentage:	0%
+   Cloud cover percentage:	0.00016431780808863243334%
+   Ice cover percentage:	100%
+   Equatorial radius:		13845.870449663006918 Km
+   Density:			5.7389510634495087362 grams/cc
+   Escape Velocity:		24.798410557599402965 Km/sec
+   Molecular weight retained:	0.11794052459249263876 and above
+   Surface acceleration:	1407.9801061778824242 cm/sec2
+   Axial tilt:			71.95072852746854153 degrees
+   Planetary albedo:		0.69999970422794539606
 
 
-Planet 9	*gas giant*
-   Distance from primary star:	22.601650198597053517 AU
-   Eccentricity of orbit:	8.979350855544408494e-05
-   Length of year:		39245.661125036580042 days
-   Length of day:		18.753690684296369002 hours
-   Mass:			24.417949024602892162 Earth masses
-   Equatorial radius:		36406.358085442627083 Km
-   Density:			0.72202901767148272723 grams/cc
-   Escape Velocity:		23.56412694308517035 Km/sec
-   Molecular weight retained:	0.5156983854782689041 and above
-   Surface acceleration:	404.4697545409456476 cm/sec2
-   Axial tilt:			45.505667614891009976 degrees
-   Planetary albedo:		0.29249931892743866115
+Planet 9
+   Distance from primary star:	8.513766991968543736 AU
+   Eccentricity of orbit:	0.26732381017985962416
+   Length of year:		9073.605439262883736 days
+   Length of day:		29.682044138447651898 hours
+   Mass:			0.16637302211024558224 Earth masses
+   Surface gravity:		0.16894475715113473151 Earth gees
+   Surface pressure:		0.006649017994797581228 Earth atmospheres
+   Surface temperature:		-203.05727757598712913 degrees Celcius
+   Boiling point of water:	-0.7439570200750154072 degrees Celcius
+   Hydrosphere percentage:	0%
+   Cloud cover percentage:	6.5015929593217930753e-06%
+   Ice cover percentage:	100%
+   Equatorial radius:		4581.966174317771328 Km
+   Density:			2.4677686770747136206 grams/cc
+   Escape Velocity:		5.3813522869930695744 Km/sec
+   Molecular weight retained:	0.7825496360189401109 and above
+   Surface acceleration:	165.67821027161753533 cm/sec2
+   Axial tilt:			69.09408391815529171 degrees
+   Planetary albedo:		0.69999998829713262885
 
 
-Planet 10	*gas giant*
-   Distance from primary star:	39.888186319105942656 AU
-   Eccentricity of orbit:	0.06503024073423179277
-   Length of year:		92015.80916611367772 days
-   Length of day:		32.83751337651664433 hours
-   Mass:			2.0594285295155744181 Earth masses
-   Equatorial radius:		37364.11537494416701 Km
-   Density:			0.056332599141871933487 grams/cc
-   Escape Velocity:		9.596635111787406495 Km/sec
-   Molecular weight retained:	0.0145350391545131078745 and above
-   Surface acceleration:	144.40662744323749245 cm/sec2
-   Axial tilt:			151.94237917546814742 degrees
-   Planetary albedo:		0.29003981518499750007
+Planet 10
+   Distance from primary star:	11.8687356167491953034 AU
+   Eccentricity of orbit:	0.061392966444465838565
+   Length of year:		14934.9121838301220135 days
+   Length of day:		16.982531589840163302 hours
+   Mass:			2.0981149032433221494 Earth masses
+   Surface gravity:		0.5510139952104049548 Earth gees
+   Surface pressure:		1.0858041005669456881 Earth atmospheres
+   Surface temperature:		-215.47655502384027908 degrees Celcius
+   Boiling point of water:	102.49902736538558656 degrees Celcius
+   Hydrosphere percentage:	0%
+   Cloud cover percentage:	7.2921776009586867925e-06%
+   Ice cover percentage:	100%
+   Equatorial radius:		9309.664180320601219 Km
+   Density:			3.7102604839948678853 grams/cc
+   Escape Velocity:		13.406750804600690026 Km/sec
+   Molecular weight retained:	0.08405950407681758756 and above
+   Surface acceleration:	540.36013961301175496 cm/sec2
+   Axial tilt:			33.80190300747907628 degrees
+   Planetary albedo:		0.69999998687408027386
+
+
+Planet 11
+   Distance from primary star:	16.88531799247696869 AU
+   Eccentricity of orbit:	0.014376799700835180518
+   Length of year:		25343.03190957870707 days
+   Length of day:		15.237297381338226849 hours
+   Mass:			4.067525644127660672 Earth masses
+   Surface gravity:		0.6119032866417497578 Earth gees
+   Surface pressure:		0.0120920077684181587456 Earth atmospheres
+   Surface temperature:		-225.08760779237150491 degrees Celcius
+   Boiling point of water:	8.336246596946864429 degrees Celcius
+   Hydrosphere percentage:	0%
+   Cloud cover percentage:	1.3621055157084017613e-08%
+   Ice cover percentage:	100%
+   Equatorial radius:		11630.27675240751977 Km
+   Density:			3.6892435796440991175 grams/cc
+   Escape Velocity:		16.701136887037237175 Km/sec
+   Molecular weight retained:	0.026125210791104807668 and above
+   Surface acceleration:	600.07213659453150395 cm/sec2
+   Axial tilt:			28.91745407649730737 degrees
+   Planetary albedo:		0.6999999999754820563
+
+
+Planet 12
+   Distance from primary star:	30.552695561225659313 AU
+   Eccentricity of orbit:	0.052863979514987378965
+   Length of year:		61683.74446128399258 days
+   Length of day:		18.819276414623926157 hours
+   Mass:			1.422646223162282839 Earth masses
+   Surface gravity:		0.43382761968475311163 Earth gees
+   Surface pressure:		0.0016112670622901790832 Earth atmospheres
+   Surface temperature:		-237.07262671276330697 degrees Celcius
+   Boiling point of water:	-20.090866885430102684 degrees Celcius
+   Hydrosphere percentage:	0%
+   Cloud cover percentage:	3.2797698212288808774e-09%
+   Ice cover percentage:	100%
+   Equatorial radius:		8495.0968599094565725 Km
+   Density:			3.3110755362271012579 grams/cc
+   Escape Velocity:		11.556869268359220587 Km/sec
+   Molecular weight retained:	0.017321662840161312155 and above
+   Surface acceleration:	425.43956265814839443 cm/sec2
+   Axial tilt:			118.34700701259639288 degrees
+   Planetary albedo:		0.69999999999409637
+
+
+Planet 13
+   Distance from primary star:	48.68595445511129124 AU
+   Eccentricity of orbit:	0.09934935442619125915
+   Length of year:		124080.29614990914407 days
+   Length of day:		32.13235082666719947 hours
+   Mass:			0.10742264348463640272 Earth masses
+   Surface gravity:		0.15165509584148579587 Earth gees
+   Surface pressure:		9.771287657235106921e-06 Earth atmospheres
+   Surface temperature:		-243.78272750653087068 degrees Celcius
+   Boiling point of water:	-71.63872564413864552 degrees Celcius
+   Hydrosphere percentage:	0%
+   Cloud cover percentage:	6.194952749496546433e-10%
+   Ice cover percentage:	100%
+   Equatorial radius:		3985.7253968826190182 Km
+   Density:			2.420755302308475571 grams/cc
+   Escape Velocity:		4.6362851734778488754 Km/sec
+   Molecular weight retained:	0.047254645737289595866 and above
+   Surface acceleration:	148.72284456339066248 cm/sec2
+   Axial tilt:			73.1545320990255874 degrees
+   Planetary albedo:		0.69999999999888486407

--- a/tests/golden/stargen_seed_7.txt
+++ b/tests/golden/stargen_seed_7.txt
@@ -2,197 +2,286 @@ Stargen - V$Revision: 3.0 $; seed=7
                           SYSTEM  CHARACTERISTICS
 Stellar mass: 1 solar masses
 Stellar luminosity: 0.98401110576113374486
-Age: 7.21457059109049871 billion years	(2.9479163376164575665 billion left on main sequence)
+Age: 0.29170378224102071327 billion years	(9.870783146465935564 billion left on main sequence)
 Habitable ecosphere radius: 1.2491693971174707 AU
 
 Planets present at:
-1	0.31352621900625999072 AU	0.055771788683812297612 EM	.
-2	0.5067601893389549815 AU	0.5707127415151546829 EM	o
-3	0.8210317296924010526 AU	0.08721797189763170687 EM	.
-4	1.0907448503518052304 AU	1.9170235954703192081 EM	o
-5	2.2704109662780684606 AU	17.819444607061895997 EM	o
-6	4.6111487314583936383 AU	461.33340899326759296 EM	o
-7	11.636948324750846545 AU	712.00661381628055285 EM	o
-8	35.342132632746506946 AU	0.17204660092242814302 EM	o
-9	48.153002277227958415 AU	0.2078565564626279441 EM	o
+1	0.39217583060050470868 AU	0.29596448464184359518 EM	o
+2	0.60698329122502209915 AU	0.06960839088926874302 EM	.
+3	0.8892461721956685165 AU	1.7958450540317686667 EM	o
+4	1.4329745353866131077 AU	0.72512070134817938917 EM	o
+5	2.3603690876788918696 AU	5.4693899053756836566 EM	o
+6	3.3495061939528064225 AU	0.3169212315227028971 EM	o
+7	5.2272543613826140513 AU	11.2690104621329858425 EM	o
+8	9.224971695059336633 AU	0.8866555632361124978 EM	o
+9	13.41438078700174689 AU	4.7154344507289253897 EM	o
+10	22.769594923873217032 AU	2.7920879394529905762 EM	o
+11	33.960589815472602207 AU	0.33948908116796119587 EM	o
+12	47.043036614651274525 AU	0.16482347997832523873 EM	o
 
 
 
 Planet 1
 Planet is tidally locked with one face to star.
-   Distance from primary star:	0.31352621900625999072 AU
-   Eccentricity of orbit:	0.0009528138433242713898
-   Length of year:		64.12215653567036947 days
-   Length of day:		1538.9317568560888674 hours
-   Mass:			0.055771788683812297612 Earth masses
-   Surface gravity:		0.2085303505073203471 Earth gees
+   Distance from primary star:	0.39217583060050470868 AU
+   Eccentricity of orbit:	1.6702884578436515937e-05
+   Length of year:		89.70536201204084063 days
+   Length of day:		2152.928688288980175 hours
+   Mass:			0.29596448464184359518 Earth masses
+   Surface gravity:		0.44420313971521497944 Earth gees
    Surface pressure:		0 Earth atmospheres
-   Surface temperature:		212.55810395631374377 degrees Celcius
+   Surface temperature:		158.4553053208479696 degrees Celcius
    Boiling point of water:	-273.14999999999997726 degrees Celcius
    Hydrosphere percentage:	0%
    Cloud cover percentage:	0%
    Ice cover percentage:	0%
-   Equatorial radius:		2945.8913031754140939 Km
-   Density:			3.1127310405101557078 grams/cc
-   Escape Velocity:		3.8857498406622995389 Km/sec
-   Molecular weight retained:	703.85159608488727745 and above
-   Surface acceleration:	204.4984161802613006 cm/sec2
+   Equatorial radius:		4632.3654496324613308 Km
+   Density:			4.2482330796554933065 grams/cc
+   Escape Velocity:		7.1382919005284796005 Km/sec
+   Molecular weight retained:	119.82584237300769861 and above
+   Surface acceleration:	435.61447200882128164 cm/sec2
    Axial tilt:			0 degrees
    Planetary albedo:		0.07000000000000000666
 
 
 Planet 2
-Planet is tidally locked with one face to star.
-   Distance from primary star:	0.5067601893389549815 AU
-   Eccentricity of orbit:	2.4789891277538846728e-06
-   Length of year:		131.76519860050980229 days
-   Length of day:		3162.364766412235255 hours
-   Mass:			0.5707127415151546829 Earth masses
-   Surface gravity:		0.63634624791481600816 Earth gees
+   Distance from primary star:	0.60698329122502209915 AU
+   Eccentricity of orbit:	0.002935009224803702098
+   Length of year:		172.72787001686430992 days
+   Length of day:		72.199804030045658665 hours
+   Mass:			0.06960839088926874302 Earth masses
+   Surface gravity:		0.25488263968492560712 Earth gees
    Surface pressure:		0 Earth atmospheres
-   Surface temperature:		103.612559662080855105 degrees Celcius
+   Surface temperature:		75.92915347319421926 degrees Celcius
    Boiling point of water:	-273.14999999999997726 degrees Celcius
    Hydrosphere percentage:	0%
    Cloud cover percentage:	0%
    Ice cover percentage:	0%
-   Equatorial radius:		5483.993192113421721 Km
-   Density:			4.937464952187883473 grams/cc
-   Escape Velocity:		9.110374737903823844 Km/sec
-   Molecular weight retained:	45.170331307654208543 and above
-   Surface acceleration:	624.0424932113830175 cm/sec2
-   Axial tilt:			0 degrees
+   Equatorial radius:		3080.6861011615027446 Km
+   Density:			3.3970068691960841653 grams/cc
+   Escape Velocity:		4.2450516923367395067 Km/sec
+   Molecular weight retained:	134.08411153356514671 and above
+   Surface acceleration:	249.95448384661756124 cm/sec2
+   Axial tilt:			71.984123357618429395 degrees
    Planetary albedo:		0.07000000000000000666
 
 
 Planet 3
-Planet is tidally locked with one face to star.
-   Distance from primary star:	0.8210317296924010526 AU
-   Eccentricity of orbit:	0.016925203648279954045
-   Length of year:		271.72976531402965727 days
-   Length of day:		6521.5143675367117746 hours
-   Mass:			0.08721797189763170687 Earth masses
-   Surface gravity:		0.28597339784168722496 Earth gees
-   Surface pressure:		0 Earth atmospheres
-   Surface temperature:		26.995828347867188768 degrees Celcius
-   Boiling point of water:	-273.14999999999997726 degrees Celcius
-   Hydrosphere percentage:	0%
-   Cloud cover percentage:	0%
-   Ice cover percentage:	0%
-   Equatorial radius:		3268.3611904200399954 Km
-   Density:			3.5644541051980019133 grams/cc
-   Escape Velocity:		4.6133231826483155603 Km/sec
-   Molecular weight retained:	67.66968130099563276 and above
-   Surface acceleration:	280.44410219441819207 cm/sec2
-   Axial tilt:			0 degrees
-   Planetary albedo:		0.07000000000000000666
+   Distance from primary star:	0.8892461721956685165 AU
+   Eccentricity of orbit:	8.8987209896042006834e-15
+   Length of year:		306.2874439318150144 days
+   Length of day:		14.929126662422609944 hours
+   Mass:			1.7958450540317686667 Earth masses
+   Surface gravity:		1.0214780660094206638 Earth gees
+   Surface pressure:		2.561081880717622185 Earth atmospheres
+   Surface temperature:		12.853889283428527435 degrees Celcius
+   Boiling point of water:	128.10937806329002342 degrees Celcius
+   Hydrosphere percentage:	91.327518311739603434%
+   Cloud cover percentage:	83.75203715855452809%
+   Ice cover percentage:	1.380885267928912459%
+   Equatorial radius:		7536.272978296268266 Km
+   Density:			5.9865439887732425383 grams/cc
+   Escape Velocity:		13.785801833561519161 Km/sec
+   Molecular weight retained:	5.7312408404598787653 and above
+   Surface acceleration:	1001.72778760312847807 cm/sec2
+   Axial tilt:			65.86225278150418205 degrees
+   Planetary albedo:		0.47355666928861355456
 
 
 Planet 4
-   Distance from primary star:	1.0907448503518052304 AU
-   Eccentricity of orbit:	1.1955605064698418415e-16
-   Length of year:		416.0838552097032845 days
-   Length of day:		15.150276434105801575 hours
-   Mass:			1.9170235954703192081 Earth masses
-   Surface gravity:		1.040459698970793655 Earth gees
-   Surface pressure:		2.8946503593228877014 Earth atmospheres
-   Surface temperature:		7.6503524674781084036 degrees Celcius
-   Boiling point of water:	132.05091160286383456 degrees Celcius
-   Hydrosphere percentage:	93.78695052013313901%
-   Cloud cover percentage:	41.979470479098097643%
-   Ice cover percentage:	4.4945614527166414913%
-   Equatorial radius:		7683.614006131094034 Km
-   Density:			6.029870956807443823 grams/cc
-   Escape Velocity:		14.106097127564481925 Km/sec
-   Molecular weight retained:	4.0170317416808648376 and above
-   Surface acceleration:	1020.3424106911933218 cm/sec2
-   Axial tilt:			131.19832162136182774 degrees
-   Planetary albedo:		0.2661695227075703773
+Cold for the habitable zone: outgassed CO2 may freeze out, risking irreversible glaciation.
+   Distance from primary star:	1.4329745353866131077 AU
+   Eccentricity of orbit:	1.10818483963958623866e-05
+   Length of year:		626.5483561266441444 days
+   Length of day:		18.216653086070249034 hours
+   Mass:			0.72512070134817938917 Earth masses
+   Surface gravity:		0.69709767934739009506 Earth gees
+   Surface pressure:		0.42778952533805831782 Earth atmospheres
+   Surface temperature:		-98.22944054845221007 degrees Celcius
+   Boiling point of water:	78.16040342824305753 degrees Celcius
+   Hydrosphere percentage:	0%
+   Cloud cover percentage:	0.21981069914335382217%
+   Ice cover percentage:	91.250175020740861564%
+   Equatorial radius:		5867.551988306823979 Km
+   Density:			5.1217295652555841433 grams/cc
+   Escape Velocity:		9.927790164142840076 Km/sec
+   Molecular weight retained:	4.331497808053466148 and above
+   Surface acceleration:	683.6192957172082822 cm/sec2
+   Axial tilt:			57.98872770267898602 degrees
+   Planetary albedo:		0.65208478277826088386
 
 
-Planet 5	*gas giant*
-   Distance from primary star:	2.2704109662780684606 AU
-   Eccentricity of orbit:	3.5783317229259853992e-22
-   Length of year:		1249.5177934578438476 days
-   Length of day:		16.53623395266104701 hours
-   Mass:			17.819444607061895997 Earth masses
-   Equatorial radius:		40051.37281545805566 Km
-   Density:			0.39574835839306778812 grams/cc
-   Escape Velocity:		23.194277788071483373 Km/sec
-   Molecular weight retained:	0.452494374506283894 and above
-   Surface acceleration:	856.3714449493288468 cm/sec2
-   Axial tilt:			134.95278269692113327 degrees
-   Planetary albedo:		0.6080130974793938208
+Planet 5
+   Distance from primary star:	2.3603690876788918696 AU
+   Eccentricity of orbit:	2.932824999775177583e-20
+   Length of year:		1324.5356970309584153 days
+   Length of day:		11.370706244837441444 hours
+   Mass:			5.4693899053756836566 Earth masses
+   Surface gravity:		1.8405926731184545715 Earth gees
+   Surface pressure:		25.064070086542273525 Earth atmospheres
+   Surface temperature:		-144.93670297287883386 degrees Celcius
+   Boiling point of water:	216.92259061748063687 degrees Celcius
+   Hydrosphere percentage:	0%
+   Cloud cover percentage:	0.0062543047260693217808%
+   Ice cover percentage:	100%
+   Equatorial radius:		10064.016840426345952 Km
+   Density:			7.6560013006017815346 grams/cc
+   Escape Velocity:		20.818990901642355603 Km/sec
+   Molecular weight retained:	0.37248177215347849612 and above
+   Surface acceleration:	1805.0048137837091854 cm/sec2
+   Axial tilt:			59.24307197326201191 degrees
+   Planetary albedo:		0.6999887422514930308
 
 
-Planet 6	*gas giant*
-   Distance from primary star:	4.6111487314583936383 AU
-   Eccentricity of orbit:	2.6236708934887649273e-847
-   Length of year:		3614.1837382443345015 days
-   Length of day:		8.905578879471576206 hours
-   Mass:			461.33340899326759296 Earth masses
-   Equatorial radius:		70504.46336743582673 Km
-   Density:			1.8782017927530618877 grams/cc
-   Escape Velocity:		71.291883705759057775 Km/sec
-   Molecular weight retained:	0.47681661191205888757 and above
-   Surface acceleration:	2363.2258305457249485 cm/sec2
-   Axial tilt:			111.81751114973518213 degrees
-   Planetary albedo:		0.62872985639026910467
+Planet 6
+   Distance from primary star:	3.3495061939528064225 AU
+   Eccentricity of orbit:	0.0007007922290356189449
+   Length of year:		2239.073395837830151 days
+   Length of day:		21.780075884852353376 hours
+   Mass:			0.3169212315227028971 Earth masses
+   Surface gravity:		0.47180618049573102977 Earth gees
+   Surface pressure:		0.079944453987573099554 Earth atmospheres
+   Surface temperature:		-146.59172166446727203 degrees Celcius
+   Boiling point of water:	41.45478768435185657 degrees Celcius
+   Hydrosphere percentage:	0%
+   Cloud cover percentage:	0.0007073988940063933319%
+   Ice cover percentage:	63.128804149286761576%
+   Equatorial radius:		4640.334327834152642 Km
+   Density:			4.525647225603868151 grams/cc
+   Escape Velocity:		7.3803497281253978143 Km/sec
+   Molecular weight retained:	1.5590710461854877967 and above
+   Surface acceleration:	462.68380799584605315 cm/sec2
+   Axial tilt:			150.0309658426567978 degrees
+   Planetary albedo:		0.49720909485002646468
 
 
-Planet 7	*gas giant*
-   Distance from primary star:	11.636948324750846545 AU
-   Eccentricity of orbit:	5.2216773392626168924e-504
-   Length of year:		14484.113041561413252 days
-   Length of day:		8.788206146452257691 hours
-   Mass:			712.00661381628055285 Earth masses
-   Equatorial radius:		67301.40590031913779 Km
-   Density:			3.3326430215519220203 grams/cc
-   Escape Velocity:		79.9904834187151771 Km/sec
-   Molecular weight retained:	0.47159692297681727363 and above
-   Surface acceleration:	2057.7959592826749762 cm/sec2
-   Axial tilt:			110.83072817495646234 degrees
-   Planetary albedo:		0.29923408174067279522
+Planet 7
+   Distance from primary star:	5.2272543613826140513 AU
+   Eccentricity of orbit:	1.2516707527759341545e-19
+   Length of year:		4365.162905083191034 days
+   Length of day:		10.629150662388044168 hours
+   Mass:			11.2690104621329858425 Earth masses
+   Surface gravity:		1.8071314210148613673 Earth gees
+   Surface pressure:		41.936912027553454596 Earth atmospheres
+   Surface temperature:		-187.44378088476189248 degrees Celcius
+   Boiling point of water:	242.68691876126774787 degrees Celcius
+   Hydrosphere percentage:	0%
+   Cloud cover percentage:	0.00016907991313199371617%
+   Ice cover percentage:	100%
+   Equatorial radius:		13503.8746933816671385 Km
+   Density:			6.5296178146575030747 grams/cc
+   Escape Velocity:		25.798211673216898926 Km/sec
+   Molecular weight retained:	0.055356681789392302436 and above
+   Surface acceleration:	1772.190534989538957 cm/sec2
+   Axial tilt:			51.1765318365411801 degrees
+   Planetary albedo:		0.699999695656156318
 
 
 Planet 8
-   Distance from primary star:	35.342132632746506946 AU
-   Eccentricity of orbit:	0.07602149340140831936
-   Length of year:		76742.57636775651761 days
-   Length of day:		29.70207612841123077 hours
-   Mass:			0.17204660092242814302 Earth masses
-   Surface gravity:		0.16579081116129128864 Earth gees
-   Surface pressure:		2.3231855313172877937e-05 Earth atmospheres
-   Surface temperature:		-238.75394555195418415 degrees Celcius
-   Boiling point of water:	-64.42610265475278197 degrees Celcius
+   Distance from primary star:	9.224971695059336633 AU
+   Eccentricity of orbit:	0.056339094068830365866
+   Length of year:		10233.974808820510636 days
+   Length of day:		20.186042693435090738 hours
+   Mass:			0.8866555632361124978 Earth masses
+   Surface gravity:		0.40693537786783396518 Earth gees
+   Surface pressure:		0.20671766434140882084 Earth atmospheres
+   Surface temperature:		-207.10922768500574401 degrees Celcius
+   Boiling point of water:	61.243734392810779354 degrees Celcius
    Hydrosphere percentage:	0%
-   Cloud cover percentage:	1.1063851115381014385e-09%
+   Cloud cover percentage:	1.0180688595202753885e-05%
    Ice cover percentage:	100%
-   Equatorial radius:		4662.5855291810445475 Km
-   Density:			2.4218254609043819304 grams/cc
-   Escape Velocity:		5.4248227554010855964 Km/sec
-   Molecular weight retained:	0.06495218222804734746 and above
-   Surface acceleration:	162.58524582748771554 cm/sec2
-   Axial tilt:			25.433935205149946768 degrees
-   Planetary albedo:		0.6999999999980084624
+   Equatorial radius:		7193.5888647794637216 Km
+   Density:			3.3985626696832418887 grams/cc
+   Escape Velocity:		9.914722779593863525 Km/sec
+   Molecular weight retained:	0.19818875139083399676 and above
+   Surface acceleration:	399.06728233675938067 cm/sec2
+   Axial tilt:			68.322746409393374734 degrees
+   Planetary albedo:		0.69999998167476048426
 
 
 Planet 9
-   Distance from primary star:	48.153002277227958415 AU
-   Eccentricity of orbit:	0.047550650639230175347
-   Length of year:		122048.45275855971498 days
-   Length of day:		29.122216278693095667 hours
-   Mass:			0.2078565564626279441 Earth masses
-   Surface gravity:		0.16318422612652187704 Earth gees
-   Surface pressure:		3.199504149733132231e-05 Earth atmospheres
-   Surface temperature:		-243.71589010350684508 degrees Celcius
-   Boiling point of water:	-61.62828473342790403 degrees Celcius
+   Distance from primary star:	13.41438078700174689 AU
+   Eccentricity of orbit:	0.025163375710269352914
+   Length of year:		17945.279511679049762 days
+   Length of day:		13.962036016360569664 hours
+   Mass:			4.7154344507289253897 Earth masses
+   Surface gravity:		0.8836405178197137664 Earth gees
+   Surface pressure:		5.880859608517528369 Earth atmospheres
+   Surface temperature:		-219.29786868225603769 degrees Celcius
+   Boiling point of water:	156.4842196556094791 degrees Celcius
    Hydrosphere percentage:	0%
-   Cloud cover percentage:	7.664001720642695758e-10%
+   Cloud cover percentage:	7.925840604725875551e-06%
    Ice cover percentage:	100%
-   Equatorial radius:		5024.851634644556389 Km
-   Density:			2.3376052656022842321 grams/cc
-   Escape Velocity:		5.7437582549212896263 Km/sec
-   Molecular weight retained:	0.031070029414713333 and above
-   Surface acceleration:	160.02905911436557061 cm/sec2
-   Axial tilt:			102.515634535062588384 degrees
-   Planetary albedo:		0.69999999999862043534
+   Equatorial radius:		11474.309662445018474 Km
+   Density:			4.4536818693081156218 grams/cc
+   Escape Velocity:		18.103955914253576193 Km/sec
+   Molecular weight retained:	0.035042488476046073706 and above
+   Surface acceleration:	866.5553284076695686 cm/sec2
+   Axial tilt:			92.96372785156266616 degrees
+   Planetary albedo:		0.6999999857334868671
+
+
+Planet 10
+   Distance from primary star:	22.769594923873217032 AU
+   Eccentricity of orbit:	0.02092666599901197237
+   Length of year:		39685.19270931081042 days
+   Length of day:		16.575608888449820265 hours
+   Mass:			2.7920879394529905762 Earth masses
+   Surface gravity:		0.5094444378580054425 Earth gees
+   Surface pressure:		0.005639918236345306149 Earth atmospheres
+   Surface temperature:		-231.62030626235394948 degrees Celcius
+   Boiling point of water:	-3.1410742479515647574 degrees Celcius
+   Hydrosphere percentage:	0%
+   Cloud cover percentage:	6.6575383452230331197e-09%
+   Ice cover percentage:	100%
+   Equatorial radius:		10482.165040399912912 Km
+   Density:			3.4590217350348832286 grams/cc
+   Escape Velocity:		14.575214675115903374 Km/sec
+   Molecular weight retained:	0.019122089008817540396 and above
+   Surface acceleration:	499.59432965202088872 cm/sec2
+   Axial tilt:			137.3663189520404444 degrees
+   Planetary albedo:		0.69999999998801638667
+
+
+Planet 11
+   Distance from primary star:	33.960589815472602207 AU
+   Eccentricity of orbit:	0.03359059884932295681
+   Length of year:		72286.962103919668685 days
+   Length of day:		25.526281597628678615 hours
+   Mass:			0.33948908116796119587 Earth masses
+   Surface gravity:		0.24202595994854042333 Earth gees
+   Surface pressure:		9.61076747862211055e-05 Earth atmospheres
+   Surface temperature:		-238.24106520290651427 degrees Celcius
+   Boiling point of water:	-51.414064335161441477 degrees Celcius
+   Hydrosphere percentage:	0%
+   Cloud cover percentage:	1.5859896164757905501e-09%
+   Ice cover percentage:	100%
+   Equatorial radius:		5628.82073482710833 Km
+   Density:			2.7161311503228296807 grams/cc
+   Escape Velocity:		6.935537224931811215 Km/sec
+   Molecular weight retained:	0.042161544906686687275 and above
+   Surface acceleration:	237.34638801293538543 cm/sec2
+   Axial tilt:			30.229082738401668706 degrees
+   Planetary albedo:		0.69999999999714517424
+
+
+Planet 12
+   Distance from primary star:	47.043036614651274525 AU
+   Eccentricity of orbit:	0.10857524354812606404
+   Length of year:		117852.89969620477704 days
+   Length of day:		30.574266200185495746 hours
+   Mass:			0.16482347997832523873 Earth masses
+   Surface gravity:		0.14790461325309759263 Earth gees
+   Surface pressure:		2.0126845031779722402e-05 Earth atmospheres
+   Surface temperature:		-243.3299965335699125 degrees Celcius
+   Boiling point of water:	-65.656381001781682016 degrees Celcius
+   Hydrosphere percentage:	0%
+   Cloud cover percentage:	7.1678084278637887923e-10%
+   Ice cover percentage:	100%
+   Equatorial radius:		4697.6703575777232955 Km
+   Density:			2.268551496621215698 grams/cc
+   Escape Velocity:		5.289860031773126684 Km/sec
+   Molecular weight retained:	0.038589818742450314165 and above
+   Surface acceleration:	145.04487755584894529 cm/sec2
+   Axial tilt:			44.123672723659190353 degrees
+   Planetary albedo:		0.69999999999870975007


### PR DESCRIPTION
## What

StarGen formed a gas giant in **~84% of systems** (`crit_mass` is low everywhere, so gas runaway is near‑inevitable); the observed giant frequency is **~10–20%** and rises steeply with stellar [Fe/H]. This adds a per‑star **giant‑formation gate** on the default path:

- draw `[Fe/H] ~ N(0, 0.20)` (solar‑neighborhood FGK MDF; Casagrande 2011 / Nordström 2004)
- accept the star as *giant‑capable* with `P = NORM·(M*/M⊙)·10^(2.0·[Fe/H])` (Fischer & Valenti 2005 slope; `NORM=0.10` calibrated via the closed form to ~12% integrated)
- if not giant‑capable, gas runaway is suppressed (`crit_mass` set unreachable) → bodies stay rocky/ice cores.

## Determinism
Three fixed draws per star in fixed order (Box‑Muller [Fe/H] + acceptance), no rejection loops. Verified **byte‑identical** across `-T1/-T2/-T4/-T8`.

## Default‑path change → goldens regenerated (deliberate)
Seeds 12345/42/7 lose their giants where the star draws non‑giant‑capable. Validated (`validate_population.py`):
```
cold-Jupiter occurrence  0.84 -> 0.123   (target ~0.10-0.20)
mean total planet mass   ~939 -> ~146 M_earth   (giants gone, expected)
mass p90  299 -> ~8 M_earth (no inflation);  density-sane 0.948 -> 0.996
architecture sane: peas 0.58, hill 26, sigma_e 0.057, mutual incl 0.99, min PR >=1
```
ctest **23/23**; `verify.sh --determinism` PASS (serial==parallel for the new output).

## Migration recalibration (bundled, `-r`‑only)
The gate shrinks the giant pool ~8×, so the `-r` migration (calibrated pre‑gate) produced ~0 hot Jupiters. Recalibrated `MIGRATION_EFFICIENCY` 1e‑4 → 5e‑4: with the gate ON, `-r` now gives **hot‑Jupiter 0.67%, cold 10.7%, cold:hot 16** — finally in the observed 10–20 band (the gate fixed the cold over‑production that made it ~169). `-r`‑only, so default goldens are unaffected by this constant.

## Known follow-ups
- Giant ⟨e⟩ still circularized by the existing gas damping (the dichotomy item).
- Metallicity is internal‑only (not yet exposed in output) — a natural [Fe/H]→iron‑fraction follow‑on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Stellar metallicity now influences gas giant formation probability, with metallicity-dependent modeling parameters.
  * Updated planet migration mechanics.

* **Updates**
  * Regenerated planetary system outputs reflecting new giant-formation criteria and migration adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->