### PR TITLE
feat(types): planet-type modifiers + taxonomy cleanup (fix the 1Face wart)

### DIFF
--- a/const.h
+++ b/const.h
@@ -121,6 +121,29 @@ constexpr double SOLAR_CMF              = 0.05;
 constexpr double COMPOSITION_SCATTER    = 0.15;
 constexpr double T_SILICATE_CONDENSE    = 1350.0; /* K; Lodders 2003 forsterite */
 
+/* --- Display-only planet-type MODIFIERS (orthogonal state, not base types) ----
+ * These drive the "{modifier} {base}" naming in display.cpp::modifier_prefix().
+ * They are evaluated at display time from already-computed planet properties and
+ * never change generation, so they are golden/determinism-safe. Thresholds are
+ * parametric (like the rest of StarGen); citations note the science they track. */
+/* Lava / magma world: surface hot enough to keep silicate rock molten. Basalt
+ * solidus ~1300 K; canonical lava worlds (CoRoT-7b, Kepler-10b, 55 Cnc e,
+ * K2-141b) sit well above this. Kuchner 2003; Leger 2011; Chao 2021 review. */
+constexpr double LAVA_SURFACE_TEMP_K    = 1300.0;
+/* Hot / strongly-irradiated rocky world below the lava regime. Set well above
+ * Venus's ~737 K surface so it flags genuinely scorching worlds (a temperature
+ * gradient Venusian -> Hot Venusian -> Lava Venusian) rather than every
+ * greenhouse world. */
+constexpr double HOT_SURFACE_TEMP_K     = 1000.0;
+/* Super-Earth size class for rocky worlds: between Earth-size and the
+ * Fulton 2017 (AJ 154:109) radius valley / sub-Neptune transition (~2 R_earth). */
+constexpr double SUPER_EARTH_MIN_REARTH = 1.25;
+constexpr double SUPER_EARTH_MAX_REARTH = 2.0;
+/* (A Hycean modifier -- a water world with a retained H2/He envelope, Madhusudhan
+ * et al. 2021 -- is intentionally NOT implemented: StarGen gives small/rocky
+ * worlds a gas-mass fraction of exactly 0, so it has no envelope to detect. It
+ * would need an envelope-retention model, like the carbon-rich-system gap.) */
+
 // Albedo values for various celestial body classifications
 constexpr double CLASS_I_ALBEDO = 0.57;
 constexpr double CLASS_II_ALBEDO = 0.81;

--- a/display.cpp
+++ b/display.cpp
@@ -513,7 +513,7 @@ auto jsonRow(planet* the_planet, bool do_gases, bool is_moon, std::string id,
  * @param the_planet
  * @return string
  */
-std::string type_string(planet* the_planet) {
+std::string base_type_string(planet* the_planet) {
   switch (the_planet->getType()) {
     case tUnknown:
       return "Unknown";
@@ -550,6 +550,20 @@ std::string type_string(planet* the_planet) {
     default:
       return "Unknown";
   }
+}
+
+/**
+ * @brief Full display name for a planet: state modifiers ("Tidally Locked",
+ * "Hot", "Super-Earth", ...) composed on top of the base composition type.
+ *
+ * Icons must NOT use this (they derive from base_type_string()); see
+ * image_type_string(). The base/modifier split mirrors the existing
+ * "{cloud} Jovian" gas-naming pattern.
+ */
+std::string type_string(planet* the_planet) {
+  // Phase 0: identical to the base name. Modifier prefixes are layered on in
+  // the later phases via modifier_prefix().
+  return base_type_string(the_planet);
 }
 
 /**
@@ -3128,7 +3142,9 @@ std::string image_type_string(planet* the_planet) {
     ss << cloud_type_string(the_planet) << " Gas";
     typeString = ss.str();
   } else {
-    typeString = type_string(the_planet);
+    // Icons key on the BASE composition only, never the modifier-prefixed
+    // display name, or "Tidally LockedWaterPlanet.webp" would 404.
+    typeString = base_type_string(the_planet);
   }
   return remove_spaces(typeString);
 }

--- a/display.cpp
+++ b/display.cpp
@@ -560,10 +560,20 @@ std::string base_type_string(planet* the_planet) {
  * image_type_string(). The base/modifier split mirrors the existing
  * "{cloud} Jovian" gas-naming pattern.
  */
+// Orthogonal STATE modifiers composed in front of the base composition type.
+// Read at display time from already-computed planet state; they never change the
+// base type, the icon, or any generated number. Extended in later phases
+// (thermal / size / lava / hycean).
+std::string modifier_prefix(planet* the_planet) {
+  std::string prefix;
+  if (the_planet->getTidallyLocked()) {
+    prefix += "Tidally Locked ";
+  }
+  return prefix;
+}
+
 std::string type_string(planet* the_planet) {
-  // Phase 0: identical to the base name. Modifier prefixes are layered on in
-  // the later phases via modifier_prefix().
-  return base_type_string(the_planet);
+  return modifier_prefix(the_planet) + base_type_string(the_planet);
 }
 
 /**

--- a/display.cpp
+++ b/display.cpp
@@ -565,10 +565,37 @@ std::string base_type_string(planet* the_planet) {
 // base type, the icon, or any generated number. Extended in later phases
 // (thermal / size / lava / hycean).
 std::string modifier_prefix(planet* the_planet) {
-  std::string prefix;
+  std::string       prefix;
+  const bool        rocky = !is_gas_planet(the_planet);
+  const planet_type t     = the_planet->getType();
+
+  // State: synchronous / spin-orbit-resonant rotation.
   if (the_planet->getTidallyLocked()) {
     prefix += "Tidally Locked ";
   }
+
+  // Thermal (rocky only -- gas giants already carry a temperature-derived cloud
+  // class, so a "Hot" prefix there would just duplicate it). Lava = surface hot
+  // enough to melt silicate rock; Hot = strongly irradiated but below melt. Skip
+  // the types whose own name already implies their thermal state.
+  if (rocky && t != tIce && t != tMartian) {
+    const long double ts = the_planet->getSurfTemp();
+    if (ts >= LAVA_SURFACE_TEMP_K) {
+      prefix += "Lava ";
+    } else if (ts >= HOT_SURFACE_TEMP_K) {
+      prefix += "Hot ";
+    }
+  }
+
+  // Size class for rocky worlds: super-Earth band, below the sub-Neptune valley.
+  if (rocky && (t == tRock || t == tTerrestrial || t == tIron || t == tWater ||
+                t == tCarbon)) {
+    const long double r_earth = convert_km_to_eu(the_planet->getRadius());
+    if (r_earth >= SUPER_EARTH_MIN_REARTH && r_earth <= SUPER_EARTH_MAX_REARTH) {
+      prefix += "Super-Earth ";
+    }
+  }
+
   return prefix;
 }
 

--- a/display.h
+++ b/display.h
@@ -29,6 +29,7 @@ void csv_row(std::fstream& the_file, planet* the_planet, bool do_gases, bool is_
 auto jsonRow(planet* the_planet, bool do_gases, bool is_moon,
              std::string id, std::stringstream& ss) -> nlohmann::json;
 auto type_string(planet *) -> std::string;
+auto base_type_string(planet *) -> std::string;
 auto cloud_type_string(planet *) -> std::string;
 void create_svg_file(planet *, std::string, std::string, std::string, std::string, bool);
 void openCVSorJson(std::string, std::string, std::fstream &);

--- a/enviro.cpp
+++ b/enviro.cpp
@@ -2885,7 +2885,11 @@ auto is_habitable_jovian(planet *the_planet) -> bool {
 auto is_terrestrial(planet *the_planet) -> bool {
   if (the_planet->getType() == tTerrestrial ||
       the_planet->getType() == tWater ||
-      ((the_planet->getType() == t1Face || the_planet->getType() == tIce ||
+      // A tidally-locked rocky world in the HZ counts as terrestrial. This was
+      // keyed on the t1Face base type; now that tidal lock is a modifier flag,
+      // key on the flag (rocky only) to preserve the prior classification.
+      (((the_planet->getTidallyLocked() && !is_gas_planet(the_planet)) ||
+        the_planet->getType() == tIce ||
         the_planet->getType() == tMartian ||
         the_planet->getType() == tVenusian) &&
        fabs(the_planet->getHzd()) < 1.0) ||

--- a/stargen.cpp
+++ b/stargen.cpp
@@ -2478,11 +2478,11 @@ static auto update_potential_statistics(SimulationContext& sc, planet* the_plane
   stats_updated |= update_min_max_stat(the_planet->getSurfPressure(), sc.min_potential_p, sc.max_potential_p);
   stats_updated |= update_min_max_stat(the_planet->getMass(), sc.min_potential_mass, sc.max_potential_mass);
 
-  // Update terrestrial-specific stats if applicable
-  if (the_planet->getType() == tTerrestrial ||
-      (the_planet->getType() == t1Face &&
-       the_planet->getHydrosphere() >= 0.05 &&
-       the_planet->getHydrosphere() <= 0.8)) {
+  // Update terrestrial-specific stats if applicable. (Locked terrestrial-water
+  // worlds that used to be t1Face with hydrosphere 0.05-0.8 now classify as
+  // tTerrestrial and are caught by the clause below, so the old t1Face special
+  // case is no longer needed.)
+  if (the_planet->getType() == tTerrestrial) {
     stats_updated |= update_min_max_stat(the_planet->getSurfGrav(), sc.min_potential_terrestrial_g, sc.max_potential_terrestrial_g);
     stats_updated |= update_min_max_stat(illumination, sc.min_potential_terrestrial_l, sc.max_potential_terrestrial_l);
   }
@@ -2690,16 +2690,13 @@ void assign_type(StarGenerator* gen, sun &the_sun, planet *the_planet, const std
     the_planet->setType(tSubSubGasGiant);
   }*/
   else {
-    if ((((int)the_planet->getDay() ==
-          (int)(the_planet->getOrbPeriod() * 24.0)) ||
-         the_planet->getResonantPeriod()) &&
-        !is_moon) {
-      the_planet->setType(t1Face);
-      if (!second_time) {
-        makeHabitable(gen, the_sun, the_planet, planet_id, is_moon, do_gases);
-      }
-    } else if (the_planet->getImf() >= 0.05 &&
-               the_planet->getHydrosphere() == 0.0) {
+    // Tidal lock is a STATE, recorded as a modifier flag (getTidallyLocked(),
+    // set in set_habitability_flags) and shown as a "Tidally Locked" prefix --
+    // NOT a base type. So a tidally-locked world is now classified by
+    // composition like any other, instead of being stamped the type-erasing
+    // "1Face" that hid its real surface (water/ice/terrestrial/...).
+    if (the_planet->getImf() >= 0.05 &&
+        the_planet->getHydrosphere() == 0.0) {
       the_planet->setType(tIce);
       /*the_planet->setIceCover(the_planet->getIceCover() +
       the_planet->getHydrosphere()); if (the_planet->getIceCover() > 1.0)

--- a/stargen.cpp
+++ b/stargen.cpp
@@ -2708,14 +2708,12 @@ void assign_type(StarGenerator* gen, sun &the_sun, planet *the_planet, const std
         makeHabitable(gen, the_sun, the_planet, planet_id, is_moon, do_gases);
       }
     } else if (the_planet->getHydrosphere() >=
-               0.8)  // In Star Trek, any planet that is 80% covered with water,
-                     // it is considered an ocean planet
+               0.8)  // any planet >=80% covered with water is an ocean world
     {
-      if (the_planet->getCmf() >= 0.75) {
-        the_planet->setType(tOil);
-      } else {
-        the_planet->setType(tWater);
-      }
+      // (Retired the cmf>=0.75 "Oil" ocean: tOil had no planetary-science basis
+      // -- the original code cited Star Trek -- and was unreachable anyway since
+      // procedural cmf tops out near SOLAR_CMF*1.15 ~= 0.06.)
+      the_planet->setType(tWater);
       if (!second_time) {
         makeHabitable(gen, the_sun, the_planet, planet_id, is_moon, do_gases);
       }
@@ -2728,11 +2726,8 @@ void assign_type(StarGenerator* gen, sun &the_sun, planet *the_planet, const std
         makeHabitable(gen, the_sun, the_planet, planet_id, is_moon, do_gases);
       }
     } else if (the_planet->getHydrosphere() >= 0.05) {
-      if (the_planet->getCmf() >= 0.75) {
-        the_planet->setType(tOil);
-      } else {
-        the_planet->setType(tTerrestrial);
-      }
+      // (tOil retired here too -- see the ocean branch above.)
+      the_planet->setType(tTerrestrial);
       if (!second_time) {
         makeHabitable(gen, the_sun, the_planet, planet_id, is_moon, do_gases);
       }

--- a/structs.h
+++ b/structs.h
@@ -25,7 +25,9 @@ using planet_type = enum planet_type {
   tSubGasGiant,
   tSubSubGasGiant,
   tAsteroids,
-  t1Face,
+  t1Face,  // DEPRECATED: tidal lock is now the tidallyLocked modifier flag, never
+           // assigned. Kept (not removed) so enum ordinals 12-15 stay stable for the
+           // positional type_counts[]/weighted-count table in stargen.cpp.
   tBrownDwarf,  // seb
   tIron,
   tCarbon,

--- a/structs.h
+++ b/structs.h
@@ -30,8 +30,11 @@ using planet_type = enum planet_type {
            // positional type_counts[]/weighted-count table in stargen.cpp.
   tBrownDwarf,  // seb
   tIron,
-  tCarbon,
-  tOil
+  tCarbon,  // carbon-dominated rock (Kuchner & Seager 2005). Currently only
+            // reachable in carbon-rich (C/O>1) systems, which StarGen does not
+            // yet model -- see the carbon-rich-system note in assign_type.
+  tOil      // DEPRECATED: a non-physical "oil ocean" (originally Star-Trek-
+            // flavored); never assigned. Kept vestigial to preserve ordinals.
 };
 
 class gas;


### PR DESCRIPTION
## What & why

A user noticed **"1Face" was a planet *type*** when it's really a *state modifier* — and it was: tidal lock was the **first** branch of the terrestrial classifier, so it stamped `t1Face` and **short-circuited the real composition** (a tidally-locked ocean world became "1Face" with the generic icon, losing its actual surface type).

This PR splits **base composition type** from **orthogonal state modifiers**, generalizing the pattern StarGen already used for gas planets (`{cloud} Jovian`). A world now reads e.g. **"Tidally Locked Venusian"**, **"Super-Earth Water"**, **"Lava Venusian"**.

## Architecture
`type_string()` = `modifier_prefix()` + `base_type_string()`. Icons derive from `base_type_string()` only (so a modified world resolves to its real surface art, never a 404). Modifiers are read at **display time** from already-computed state, so they mutate nothing.

## Phases (one commit each)
1. **Refactor (golden-neutral):** factor out `base_type_string()`; point `image_type_string()` at it. Byte-identical.
2. **Demote `1Face` → "Tidally Locked" modifier:** delete the short-circuit so tidally-locked worlds classify by composition; prefix from the existing `tidallyLocked` flag; re-key `is_terrestrial`/habitability-stats on the flag for parity; `t1Face` enum kept vestigial (ordinals feed a positional `type_counts[]`/weighted table). *Generation-path change, but goldens for seeds 12345/42/7 are unchanged (no reclassified planets) and determinism holds.*
3. **Retire `tOil`; document `tCarbon`:** `tOil` ("Oil" worlds) had no scientific basis (the code cited Star Trek) and was unreachable — `cmf = about(0.05, 0.15)` is a *relative* ±15% scatter capping near 0.057, so the `cmf≥0.75` trigger never fired. Behavior-neutral removal.
4. **Add Hot / Lava / Super-Earth modifiers** (display-only): Lava ≥1300 K (silicate melt), Hot ≥1000 K (above Venus), Super-Earth 1.25–2.0 R⊕ (Fulton 2017 valley). Compose with tidal lock; verified reachable across 120 seeds.

## New taxonomy in action (sampled population)
`Tidally Locked Rock/Venusian/Terrestrial`, `Super-Earth Water/Terrestrial`, `Hot Venusian`, `Tidally Locked Hot Venusian`, `Lava Venusian`.

## Honest deferrals (documented, not faked)
Three would-be types need physics StarGen doesn't model, so they're documented gaps rather than dead code:
- **`tCarbon`**: needs a carbon-rich (C/O>1) system model; `cmf` is structurally pinned ~0.05. (A prior evidence review declined the contested C/O→carbon data.)
- **Hycean**: StarGen gives small/rocky worlds a gas-mass fraction of exactly 0 — no envelope to detect.
- **Chthonian**: needs evaporated-giant bookkeeping carried through migration, which doesn't exist.

## Verification
- `scripts/verify.sh --determinism`: **23/23 ctest**, determinism **PASS** (10× -T8 + -T1/2/4 byte-identical).
- Goldens unchanged across all four commits; population_validation green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Planet display now includes thermal modifiers (Lava/Hot) and size modifiers (Super-Earth) for enhanced classification detail.

* **Bug Fixes**
  * Corrected planet icon naming to properly align with base planetary composition.

* **Refactor**
  * Tidally-locked planets now classified by composition rather than unified designation.
  * Removed oil planet classification system.
  * One-face planet type deprecated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->