### PR TITLE
feat(types): real Carbon planets + Hycean worlds (Chthonian investigated, deferred)

### DIFF
--- a/accrete.cpp
+++ b/accrete.cpp
@@ -899,6 +899,10 @@ auto accrete::dist_planetary_masses(sun &the_sun, long double inner_dust,
         GIANT_METALLICITY_MEAN +
         GIANT_METALLICITY_SIGMA * sqrt(-2.0L * log(u1)) * cos(2.0L * PI * u2);
     the_sun.setMetallicity(feh);  // expose the per-star [Fe/H] in output
+    // Carbon-rich (C/O>1) systems: a deterministic per-system flag hashed from
+    // the seed (NO RNG draw -> stream unperturbed) that makes rocky bodies
+    // carbon-dominated (-> tCarbon). See assign_composition() / const.h.
+    the_sun.setCarbonRich(carbon_rich_from_seed(random_ctx->getSeed()));
     long double p_giant = GIANT_FORMATION_NORM * stell_mass_ratio *
                           std::pow(10.0L, GIANT_FORMATION_FEH_SLOPE * feh);
     if (stell_mass_ratio > GIANT_FORMATION_MASS_TURNOVER_MSUN) {  // steep drop for A-stars

--- a/const.h
+++ b/const.h
@@ -119,6 +119,18 @@ constexpr double IRON_REFRACTORY_FRACTION = 0.33;
 constexpr double ICE_MAX_FRACTION       = 0.5;
 constexpr double SOLAR_CMF              = 0.05;
 constexpr double COMPOSITION_SCATTER    = 0.15;
+/* Carbon planets: a fraction of systems form in carbon-rich (C/O>1) disks where
+ * carbon/carbides condense before silicates, so rock is carbon-dominated rather
+ * than silicate (Kuchner & Seager 2005; Bond et al. 2010). CARBON_RICH_SYSTEM_
+ * FRACTION is the per-system probability -- a deliberately conservative value at
+ * the high end of the C/O>1 host fraction (Fortney 2012); the once-claimed ~25%
+ * C/O>0.8 figure was a large overestimate (Nissen 2013; Brewer & Fischer 2016
+ * find genuine C/O>1 hosts are rare). In a carbon-rich system rocky bodies get
+ * carbon-of-rock fraction ~ CARBON_RICH_CMF_MEAN (vs solar ~0.05), crossing the
+ * existing cmf>=0.75 tCarbon threshold. The flag is a pure hash of the system
+ * seed (no RNG draw), so non-carbon-rich systems are byte-unchanged. */
+constexpr double CARBON_RICH_SYSTEM_FRACTION = 0.05;
+constexpr double CARBON_RICH_CMF_MEAN        = 0.75;
 constexpr double T_SILICATE_CONDENSE    = 1350.0; /* K; Lodders 2003 forsterite */
 
 /* --- Display-only planet-type MODIFIERS (orthogonal state, not base types) ----

--- a/const.h
+++ b/const.h
@@ -139,10 +139,22 @@ constexpr double HOT_SURFACE_TEMP_K     = 1000.0;
  * Fulton 2017 (AJ 154:109) radius valley / sub-Neptune transition (~2 R_earth). */
 constexpr double SUPER_EARTH_MIN_REARTH = 1.25;
 constexpr double SUPER_EARTH_MAX_REARTH = 2.0;
-/* (A Hycean modifier -- a water world with a retained H2/He envelope, Madhusudhan
- * et al. 2021 -- is intentionally NOT implemented: StarGen gives small/rocky
- * worlds a gas-mass fraction of exactly 0, so it has no envelope to detect. It
- * would need an envelope-retention model, like the carbon-rich-system gap.) */
+/* Hycean world (Madhusudhan et al. 2021, ApJ 918:1): a water/volatile-rich world
+ * under a H2/He envelope, potentially habitable. StarGen gives rocky worlds no
+ * envelope, so rather than invent envelope-accretion physics this maps the
+ * Hycean regime onto StarGen's EXISTING small gas-dwarf / sub-Neptunian
+ * population in the temperate range. Mass band 1-10 M_earth is the paper's
+ * range; the equilibrium-temp floor (170 K) is dropped below the paper's ~210 K
+ * because StarGen's est_temp excludes the envelope greenhouse (true surface runs
+ * warmer); the upper bound reuses the existing "Water" cloud band (<=360 K). The
+ * radius ceiling DEVIATES from the paper's ~2.6 R_earth: StarGen's gas-dwarf
+ * radii run larger (3-7 R_earth), so a literal cut yields zero Hyceans -- 6.0 is
+ * a StarGen-population-calibrated "small gas dwarf" cut, not a literature value. */
+constexpr double HYCEAN_TEMP_MIN_K       = 170.0;
+constexpr double HYCEAN_TEMP_MAX_K       = 360.0;
+constexpr double HYCEAN_MASS_MIN_REARTH  = 1.0;
+constexpr double HYCEAN_MASS_MAX_REARTH  = 10.0;
+constexpr double HYCEAN_RADIUS_MAX_REARTH = 6.0;
 
 // Albedo values for various celestial body classifications
 constexpr double CLASS_I_ALBEDO = 0.57;

--- a/display.cpp
+++ b/display.cpp
@@ -596,6 +596,21 @@ std::string modifier_prefix(planet* the_planet) {
     }
   }
 
+  // Hycean: a temperate, water/volatile-rich gas dwarf / small Neptunian -- a
+  // water world beneath a H2/He envelope (Madhusudhan et al. 2021). StarGen
+  // gives rocky worlds no envelope, so this is recognized on the EXISTING small
+  // gas-dwarf population in the habitable-temperature range (see const.h).
+  if (!rocky && (t == tSubSubGasGiant || t == tSubGasGiant)) {
+    const long double et  = the_planet->getEstimatedTemp();
+    const long double m_e = the_planet->getMass() * SUN_MASS_IN_EARTH_MASSES;
+    const long double r_e = convert_km_to_eu(the_planet->getRadius());
+    if (et >= HYCEAN_TEMP_MIN_K && et <= HYCEAN_TEMP_MAX_K &&
+        m_e >= HYCEAN_MASS_MIN_REARTH && m_e <= HYCEAN_MASS_MAX_REARTH &&
+        r_e <= HYCEAN_RADIUS_MAX_REARTH) {
+      prefix += "Hycean ";
+    }
+  }
+
   return prefix;
 }
 

--- a/enviro.cpp
+++ b/enviro.cpp
@@ -2780,12 +2780,20 @@ void assign_composition(planet *the_planet, sun &the_sun, bool is_moon) {
   }
 
   if (the_planet->getCmf() == 0) {
-    long double cmf = about(SOLAR_CMF, COMPOSITION_SCATTER);  // carbon-of-rock, small/solar
+    // In a carbon-rich (C/O>1) system carbon/carbides condense before silicates,
+    // so rock is carbon-dominated -> high cmf -> the body classifies as tCarbon.
+    // Same single about() draw either way, so the RNG stream is unperturbed; only
+    // the value and clamp differ for carbon-rich systems.
+    const bool  carbon_rich = the_sun.getCarbonRich();
+    long double cmf         = carbon_rich
+                                 ? about(CARBON_RICH_CMF_MEAN, COMPOSITION_SCATTER)
+                                 : about(SOLAR_CMF, COMPOSITION_SCATTER);
     if (cmf < 0.0) {
       cmf = 0.0;
     }
-    if (cmf > 0.2) {
-      cmf = 0.2;
+    const long double cmf_cap = carbon_rich ? 1.0 : 0.2;
+    if (cmf > cmf_cap) {
+      cmf = cmf_cap;
     }
     the_planet->setCmf(cmf);
   }

--- a/structs.cpp
+++ b/structs.cpp
@@ -882,6 +882,9 @@ void sun::setAge(long double a) { age = a; }
 void sun::setMetallicity(long double m) { metallicity = m; }
 auto sun::getMetallicity() -> long double { return metallicity; }
 
+void sun::setCarbonRich(bool b) { carbonRich = b; }
+auto sun::getCarbonRich() -> bool { return carbonRich; }
+
 void sun::setEffTemp(long double e) {
   effTemp = e;
   if (specType.empty()) {

--- a/structs.h
+++ b/structs.h
@@ -30,9 +30,9 @@ using planet_type = enum planet_type {
            // positional type_counts[]/weighted-count table in stargen.cpp.
   tBrownDwarf,  // seb
   tIron,
-  tCarbon,  // carbon-dominated rock (Kuchner & Seager 2005). Currently only
-            // reachable in carbon-rich (C/O>1) systems, which StarGen does not
-            // yet model -- see the carbon-rich-system note in assign_type.
+  tCarbon,  // carbon-dominated rock (Kuchner & Seager 2005). Reached in carbon-
+            // rich (C/O>1) systems: sun::carbonRich (a per-system seed hash, set
+            // in accrete.cpp) boosts cmf>=0.75 in assign_composition.
   tOil      // DEPRECATED: a non-physical "oil ocean" (originally Star-Trek-
             // flavored); never assigned. Kept vestigial to preserve ordinals.
 };
@@ -64,6 +64,7 @@ class sun {
   std::string specType{""};
   long double age{0};
   long double metallicity{0};  // [Fe/H] in dex (0 = solar); drives giant formation
+  bool carbonRich{false};      // C/O>1 disk -> carbon-dominated rock (tCarbon planets)
   std::string name{""};
   bool isCircumbinary{false};
   long double secondaryMass{0};
@@ -91,6 +92,8 @@ class sun {
   auto getAge() -> long double;
   void setMetallicity(long double);
   auto getMetallicity() -> long double;
+  void setCarbonRich(bool);
+  auto getCarbonRich() -> bool;
   void setName(std::string);
   auto getName() -> std::string;
   auto getREcosphere(long double) -> long double;

--- a/utils.cpp
+++ b/utils.cpp
@@ -6,6 +6,7 @@
 #include <cctype>                   // for toupper, isspace
 #include <cmath>                    // for log, exp, pow, NAN, sqrt, fmod, abs
 #include <cstdlib>                  // for rand, abs, RAND_MAX
+#include <cstdint>                  // for std::uint64_t (carbon_rich_from_seed)
 #include <string>                   // for std::string, basic_string, operator<<
 #include "const.h"                  // for pow2, pow1_4, pow3, pow4
 #include "enviro.h"                 // for eff_temp_to_spec_type, getStarType
@@ -119,6 +120,21 @@ auto random_number_int(int min, int max) -> int {
 /// @return 
 auto about(long double value, long double variation) -> long double {
   return (value + (value * random_number(-variation, variation)));
+}
+
+/// @brief Deterministic per-system carbon-rich (C/O>1) flag from the system seed.
+/// Pure splitmix64 hash -> uniform [0,1) compared to CARBON_RICH_SYSTEM_FRACTION.
+/// Consumes NO RandomContext draw, so it does not shift the per-system RNG stream
+/// (only carbon-rich systems' composition changes); integer-only hash keeps it
+/// byte-identical across compilers/threads.
+auto carbon_rich_from_seed(long sys_seed) -> bool {
+  std::uint64_t z = static_cast<std::uint64_t>(sys_seed) + 0x9E3779B97F4A7C15ULL;
+  z = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9ULL;
+  z = (z ^ (z >> 27)) * 0x94D049BB133111EBULL;
+  z = z ^ (z >> 31);
+  // Top 53 bits -> double in [0,1).
+  const double u = static_cast<double>(z >> 11) * (1.0 / 9007199254740992.0);
+  return u < CARBON_RICH_SYSTEM_FRACTION;
 }
 
 /// @brief 

--- a/utils.h
+++ b/utils.h
@@ -42,6 +42,10 @@ auto escapeCelestiaId(const std::string&) -> std::string;
 auto random_number(long double, long double) -> long double;
 auto random_number_int(int min, int max) -> int;
 auto about(long double, long double) -> long double;
+// Deterministic per-system "carbon-rich" (C/O>1) flag from the system seed via a
+// splitmix64 hash. PURE -- consumes NO RandomContext draw, so it does not shift
+// the per-system RNG stream. True with probability CARBON_RICH_SYSTEM_FRACTION.
+auto carbon_rich_from_seed(long sys_seed) -> bool;
 auto random_eccentricity(long double) -> long double;
 auto gaussian(long double) -> long double;
 auto poisson(long double) -> long;


### PR DESCRIPTION
## What

Makes two of the three previously-deferred planet types **real**, with actual physics — and reports honestly why the third can't be (yet).

### ✅ Carbon planets (now generated)
Carbon-dominated rock from carbon-rich (C/O>1) disks (Kuchner & Seager 2005; Bond et al. 2010). The dead `tCarbon` type (its `cmf≥0.75` trigger was unreachable because `cmf` is pinned ~0.05) now fires:
- `carbon_rich_from_seed()` — a **pure splitmix64 hash** of the per-system seed, true with probability `CARBON_RICH_SYSTEM_FRACTION` (0.05, a conservative high-end estimate of the C/O>1 host fraction). Consumes **no** RandomContext draw.
- `sun::carbonRich` set once per system at the metallicity site; in carbon-rich systems `assign_composition` draws `cmf=about(0.75,0.15)` (same single draw) → crosses the `tCarbon` threshold; `cmf` feeds the Zeng radius so carbon worlds get realistic radii.
- **Golden-safe**: non-carbon-rich systems are byte-identical (no stream shift); seeds 12345/42/7 don't hash carbon-rich. Determinism verified (`-T1`==`-T8` across a run spanning carbon-rich systems). ~5% of systems produce `Carbon` / `Tidally Locked Carbon` worlds.

### ✅ Hycean worlds (now labeled)
A water world under a H2/He envelope (Madhusudhan et al. 2021). Since StarGen gives rocky worlds zero envelope, this is recognized on the **existing** temperate small gas-dwarf population (display-only modifier; 170–360 K, 1–10 M⊕, ≤6 R⊕) → e.g. `Hycean Water Gas Dwarf`. No generation/RNG change; ~1.5% of `-m1.0` systems.

### ⚠️ Chthonian — implemented, then reverted as structurally unreachable
I implemented the full energy-limited XUV photoevaporation criterion (Watson 1981 / Lammer 2003 / Erkaev 2007 / Owen & Wu 2017) inside the migration path and measured it: across 600 `-r` systems, the close-in giants StarGen produces are **gas-runaway products** (35–158 M⊕, **70–87% gas fraction**) whose envelope binding energy is ~20× too large to strip — which is physically *correct* (real gas-rich hot Saturns/Jupiters survive). True Chthonians need *thin-envelope* hot-Neptune progenitors, which StarGen doesn't generate close-in. Rather than mis-tune the binding prefactor to manufacture a result against the physics, I reverted it and documented the gap.

## Verification
- `scripts/verify.sh --determinism`: build + **23/23 ctest**, determinism PASS.
- Goldens byte-unchanged across both commits (verified).
- Reachability confirmed: Carbon fires on the 6 carbon-rich seeds in 1–120; Hycean fires on seed 3 (`-m1.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)